### PR TITLE
Add list only sub commands to collectors

### DIFF
--- a/deploy/DEPLOYMENT.md
+++ b/deploy/DEPLOYMENT.md
@@ -116,13 +116,13 @@ OSS_UPLOAD=true ./deploy/run_daily.sh
 
 **Or directly with the collector:**
 ```bash
-python tools/nba_game_collector.py --data-dir data/nba-betting --oss-upload
-python tools/nfl_game_collector.py --data-dir data/nfl --oss-upload
+python tools/nba_game_collector.py collect --data-dir data/nba-betting --oss-upload
+python tools/nfl_game_collector.py collect --data-dir data/nfl --oss-upload
 ```
 
 **Override bucket/prefix via CLI:**
 ```bash
-python tools/nba_game_collector.py --data-dir data/nba-betting \
+python tools/nba_game_collector.py collect --data-dir data/nba-betting \
     --oss-upload --oss-bucket staging-bucket --oss-prefix test/
 ```
 

--- a/deploy/run_daily.sh
+++ b/deploy/run_daily.sh
@@ -55,6 +55,7 @@ fi
 # Run collector (it handles its own logging)
 if [ -n "$TIMEOUT_CMD" ]; then
     "$TIMEOUT_CMD" "$TIMEOUT_SECONDS" python3 "$PROJECT_ROOT/tools/nba_game_collector.py" \
+        collect \
         --data-dir "$DATA_DIR" \
         --date "$DATE" \
         --log-level INFO \
@@ -62,6 +63,7 @@ if [ -n "$TIMEOUT_CMD" ]; then
     EXIT_CODE=$?
 else
     python3 "$PROJECT_ROOT/tools/nba_game_collector.py" \
+        collect \
         --data-dir "$DATA_DIR" \
         --date "$DATE" \
         --log-level INFO \

--- a/docs/nba-game-collector.md
+++ b/docs/nba-game-collector.md
@@ -2,29 +2,55 @@
 
 Automated driver for collecting replay data for NBA games. Orchestrates data collection by checking NBA API for daily games, setting up separate trials for each game, starting trials 2 hours before game time, and running until games conclude.
 
-## Usage
+## Commands
 
-**Basic (today's games):**
+### List Games
+
+List games for a date range (defaults to today):
+
 ```bash
-python tools/nba_game_collector.py --data-dir data/nba-betting
+# List today's games
+python tools/nba_game_collector.py list
+
+# List games for a specific date
+python tools/nba_game_collector.py list --start-date 2025-12-16
+
+# List games for a date range
+python tools/nba_game_collector.py list --start-date 2025-12-10 --end-date 2025-12-16
 ```
 
-**Specific date:**
+**List options:**
+- `--start-date`: Start date (YYYY-MM-DD). Default: today
+- `--end-date`: End date (YYYY-MM-DD). Default: same as start date
+- `--log-level`: Logging level (default: WARNING)
+
+### Collect Data
+
+Collect game data for a date:
+
 ```bash
-python tools/nba_game_collector.py --data-dir data/nba-betting --date 2025-12-16
+# Collect today's games
+python tools/nba_game_collector.py collect --data-dir data/nba-betting
+
+# Collect for a specific date
+python tools/nba_game_collector.py collect --data-dir data/nba-betting --date 2025-12-16
 ```
 
-**Options:**
-- `--data-dir`: **Required**. Data directory where all files are organized: `{data-dir}/{date}/{game_id}.{yaml,jsonl,log}`
+**Collect options:**
+- `--data-dir`: Data directory where all files are organized: `{data-dir}/{date}/{game_id}.{yaml,jsonl,log}`
 - `--date`: Date to collect games for (YYYY-MM-DD). Default: today
+- `--game-id`: Specific game ID to collect (optional)
 - `--base-config`: Base config template (default: `configs/nba-pregame-betting.yaml`)
 - `--pre-start-hours`: Hours before game to start trial (default: 2.0)
 - `--check-interval`: Seconds between game status checks (default: 60.0)
-- `--log-level`: Logging level for both collector and trial subprocesses: DEBUG, INFO, WARNING, ERROR (default: INFO)
+- `--log-level`: Logging level: DEBUG, INFO, WARNING, ERROR (default: INFO)
+- `--oss-upload`: Enable OSS upload after collection
+- `--oss-bucket`: Override OSS bucket name
+- `--oss-prefix`: Override OSS prefix
 
 **Debug logging:**
 ```bash
-python tools/nba_game_collector.py --data-dir data/nba-betting --log-level DEBUG
+python tools/nba_game_collector.py collect --data-dir data/nba-betting --log-level DEBUG
 ```
 
 ## File Structure

--- a/tools/nba_game_collector.py
+++ b/tools/nba_game_collector.py
@@ -781,66 +781,180 @@ async def run_collection(
     logger.info("=" * 80)
 
 
+def list_games_in_range(
+    start_date: str | None = None,
+    end_date: str | None = None,
+) -> None:
+    """List games in a date range.
+
+    Args:
+        start_date: Start date (YYYY-MM-DD). If None, defaults to today.
+        end_date: End date (YYYY-MM-DD). If None, defaults to start_date (single day).
+    """
+    # Parse start date
+    if start_date:
+        try:
+            start = datetime.strptime(start_date, "%Y-%m-%d")
+        except ValueError:
+            logger.error(
+                "Invalid start date format: %s (expected YYYY-MM-DD)", start_date
+            )
+            return
+    else:
+        start = datetime.now()
+
+    # Parse end date
+    if end_date:
+        try:
+            end = datetime.strptime(end_date, "%Y-%m-%d")
+        except ValueError:
+            logger.error("Invalid end date format: %s (expected YYYY-MM-DD)", end_date)
+            return
+    else:
+        end = start
+
+    # Ensure start <= end
+    if start > end:
+        start, end = end, start
+
+    # Iterate through date range
+    current = start
+    total_games = 0
+
+    print(f"\n{'=' * 80}")
+    print(f"NBA Games from {start.strftime('%Y-%m-%d')} to {end.strftime('%Y-%m-%d')}")
+    print(f"{'=' * 80}\n")
+
+    while current <= end:
+        date_str = current.strftime("%Y-%m-%d")
+        games = get_games_for_date(date_str, print_games=False)
+
+        if games:
+            print(f"Date: {date_str} ({len(games)} game(s))")
+            print("-" * 40)
+            for game in games:
+                game_id = game.get("gameId", "")
+                away_team = game.get("awayTeam", {}).get("teamName", "Unknown")
+                home_team = game.get("homeTeam", {}).get("teamName", "Unknown")
+                away_tricode = game.get("awayTeam", {}).get("teamTricode", "???")
+                home_tricode = game.get("homeTeam", {}).get("teamTricode", "???")
+                status_text = game.get("gameStatusText", "Unknown")
+                game_status = game.get("gameStatus", 0)
+
+                # Format time
+                time_str = "N/A"
+                if game.get("gameTimeLTZ"):
+                    time_str = game["gameTimeLTZ"].strftime("%H:%M %Z")
+
+                # Format score if game has started
+                score_str = ""
+                if game_status in (2, 3):  # In progress or finished
+                    away_score = game.get("awayTeam", {}).get("score", 0)
+                    home_score = game.get("homeTeam", {}).get("score", 0)
+                    score_str = f" | {away_score}-{home_score}"
+
+                print(
+                    f"  {game_id}: {away_tricode} @ {home_tricode} "
+                    f"({away_team} vs {home_team}) | {time_str} | {status_text}{score_str}"
+                )
+                total_games += 1
+            print()
+        else:
+            print(f"Date: {date_str} - No games scheduled\n")
+
+        current += timedelta(days=1)
+
+    print(f"{'=' * 80}")
+    print(f"Total: {total_games} game(s)")
+    print(f"{'=' * 80}\n")
+
+
 def main() -> int:
     """Main entry point."""
     parser = argparse.ArgumentParser(
         description="NBA Game Collector - Orchestrates data collection for NBA games"
     )
-    parser.add_argument(
+    subparsers = parser.add_subparsers(dest="command", help="Available commands")
+
+    # List games subcommand
+    list_parser = subparsers.add_parser("list", help="List NBA games in a date range")
+    list_parser.add_argument(
+        "--start-date",
+        type=str,
+        default=None,
+        help="Start date (YYYY-MM-DD). Default: today",
+    )
+    list_parser.add_argument(
+        "--end-date",
+        type=str,
+        default=None,
+        help="End date (YYYY-MM-DD). Default: same as start date",
+    )
+    list_parser.add_argument(
+        "--log-level",
+        type=str,
+        default="WARNING",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
+        help="Logging level (default: WARNING)",
+    )
+
+    # Collect subcommand
+    collect_parser = subparsers.add_parser("collect", help="Collect data for NBA games")
+    collect_parser.add_argument(
         "--date",
         type=str,
         default=None,
         help="Date to collect games for (YYYY-MM-DD). Default: today",
     )
-    parser.add_argument(
+    collect_parser.add_argument(
         "--game-id",
         type=str,
         default=None,
         help="Specific game ID to collect data for. If provided, only this game will be processed.",
     )
-    parser.add_argument(
+    collect_parser.add_argument(
         "--base-config",
         type=Path,
         default=Path(__file__).parent.parent / "configs" / "nba-pregame-betting.yaml",
         help="Path to base config template (default: configs/nba-pregame-betting.yaml)",
     )
-    parser.add_argument(
+    collect_parser.add_argument(
         "--data-dir",
         type=Path,
         default=None,
         help="Data directory for date-organized structure: {data-dir}/{date}/{game_id}.yaml and {data-dir}/{date}/{game_id}.jsonl",
     )
-    parser.add_argument(
+    collect_parser.add_argument(
         "--pre-start-hours",
         type=float,
         default=2.0,
         help="Hours before game to start trial (default: 2.0)",
     )
-    parser.add_argument(
+    collect_parser.add_argument(
         "--check-interval",
         type=float,
         default=60.0,
         help="Interval in seconds to check game status (default: 60.0)",
     )
-    parser.add_argument(
+    collect_parser.add_argument(
         "--log-level",
         type=str,
         default="INFO",
         choices=["DEBUG", "INFO", "WARNING", "ERROR"],
         help="Logging level (default: INFO)",
     )
-    parser.add_argument(
+    collect_parser.add_argument(
         "--oss-upload",
         action="store_true",
         help="Upload files to OSS after trial completion",
     )
-    parser.add_argument(
+    collect_parser.add_argument(
         "--oss-bucket",
         type=str,
         default=None,
         help="Override OSS bucket name (default: from DOJOZERO_OSS_BUCKET env var)",
     )
-    parser.add_argument(
+    collect_parser.add_argument(
         "--oss-prefix",
         type=str,
         default=None,
@@ -849,6 +963,13 @@ def main() -> int:
 
     args = parser.parse_args()
 
+    # Handle no command (default to collect for backward compatibility)
+    if args.command is None:
+        # Check if any collect-specific args are present for backward compatibility
+        # Re-parse with collect defaults
+        parser.print_help()
+        return 0
+
     # Configure logging
     logging.basicConfig(
         level=getattr(logging, args.log_level.upper()),
@@ -856,62 +977,74 @@ def main() -> int:
         datefmt="%Y-%m-%d %H:%M:%S",
     )
 
-    # Validate base config
-    if not args.base_config.exists():
-        logger.error("Base config file not found: %s", args.base_config)
-        return 1
-
-    # Run collection
-    try:
-        # If game_id is provided, use collect_game_for_id (trumps date logic)
-        if args.game_id:
-            managers = asyncio.run(
-                collect_game_for_id(
-                    game_id=args.game_id,
-                    base_config=args.base_config,
-                    pre_start_hours=args.pre_start_hours,
-                    check_interval_seconds=args.check_interval,
-                    data_dir=args.data_dir,
-                    log_level=args.log_level,
-                    oss_upload=args.oss_upload,
-                    oss_bucket=args.oss_bucket,
-                    oss_prefix=args.oss_prefix,
-                )
-            )
-        else:
-            # Determine date for date-based collection
-            if args.date:
-                game_date = args.date
-            else:
-                game_date = datetime.now()
-
-            managers = asyncio.run(
-                collect_games_for_date(
-                    game_date=game_date,
-                    base_config=args.base_config,
-                    pre_start_hours=args.pre_start_hours,
-                    check_interval_seconds=args.check_interval,
-                    data_dir=args.data_dir,
-                    log_level=args.log_level,
-                    oss_upload=args.oss_upload,
-                    oss_bucket=args.oss_bucket,
-                    oss_prefix=args.oss_prefix,
-                )
-            )
-
-        if not managers:
-            logger.info("No games to collect")
-            return 0
-
-        asyncio.run(run_collection(managers))
+    # Handle list command
+    if args.command == "list":
+        list_games_in_range(
+            start_date=args.start_date,
+            end_date=args.end_date,
+        )
         return 0
 
-    except KeyboardInterrupt:
-        logger.info("Interrupted by user")
-        return 130
-    except Exception as e:
-        logger.error("Fatal error: %s", e, exc_info=True)
-        return 1
+    # Handle collect command
+    if args.command == "collect":
+        # Validate base config
+        if not args.base_config.exists():
+            logger.error("Base config file not found: %s", args.base_config)
+            return 1
+
+        # Run collection
+        try:
+            # If game_id is provided, use collect_game_for_id (trumps date logic)
+            if args.game_id:
+                managers = asyncio.run(
+                    collect_game_for_id(
+                        game_id=args.game_id,
+                        base_config=args.base_config,
+                        pre_start_hours=args.pre_start_hours,
+                        check_interval_seconds=args.check_interval,
+                        data_dir=args.data_dir,
+                        log_level=args.log_level,
+                        oss_upload=args.oss_upload,
+                        oss_bucket=args.oss_bucket,
+                        oss_prefix=args.oss_prefix,
+                    )
+                )
+            else:
+                # Determine date for date-based collection
+                if args.date:
+                    game_date = args.date
+                else:
+                    game_date = datetime.now()
+
+                managers = asyncio.run(
+                    collect_games_for_date(
+                        game_date=game_date,
+                        base_config=args.base_config,
+                        pre_start_hours=args.pre_start_hours,
+                        check_interval_seconds=args.check_interval,
+                        data_dir=args.data_dir,
+                        log_level=args.log_level,
+                        oss_upload=args.oss_upload,
+                        oss_bucket=args.oss_bucket,
+                        oss_prefix=args.oss_prefix,
+                    )
+                )
+
+            if not managers:
+                logger.info("No games to collect")
+                return 0
+
+            asyncio.run(run_collection(managers))
+            return 0
+
+        except KeyboardInterrupt:
+            logger.info("Interrupted by user")
+            return 130
+        except Exception as e:
+            logger.error("Fatal error: %s", e, exc_info=True)
+            return 1
+
+    return 0
 
 
 if __name__ == "__main__":

--- a/tools/nfl_game_collector.py
+++ b/tools/nfl_game_collector.py
@@ -1118,84 +1118,215 @@ async def run_collection(managers: list[NFLGameTrialManager]) -> None:
     logger.info("=" * 80)
 
 
+async def list_games_in_range(
+    start_date: str | None = None,
+    end_date: str | None = None,
+) -> None:
+    """List NFL games in a date range.
+
+    Args:
+        start_date: Start date (YYYY-MM-DD). If None, defaults to today.
+        end_date: End date (YYYY-MM-DD). If None, defaults to start_date (single day).
+    """
+    # Parse start date
+    if start_date:
+        try:
+            start = datetime.strptime(start_date, "%Y-%m-%d")
+        except ValueError:
+            logger.error(
+                "Invalid start date format: %s (expected YYYY-MM-DD)", start_date
+            )
+            return
+    else:
+        start = datetime.now()
+
+    # Parse end date
+    if end_date:
+        try:
+            end = datetime.strptime(end_date, "%Y-%m-%d")
+        except ValueError:
+            logger.error("Invalid end date format: %s (expected YYYY-MM-DD)", end_date)
+            return
+    else:
+        end = start
+
+    # Ensure start <= end
+    if start > end:
+        start, end = end, start
+
+    # Iterate through date range
+    current = start
+    total_games = 0
+
+    print(f"\n{'=' * 80}")
+    print(f"NFL Games from {start.strftime('%Y-%m-%d')} to {end.strftime('%Y-%m-%d')}")
+    print(f"{'=' * 80}\n")
+
+    while current <= end:
+        date_str = current.strftime("%Y-%m-%d")
+        games = await get_nfl_games_for_date(date_str, print_games=False)
+
+        if games:
+            print(f"Date: {date_str} ({len(games)} game(s))")
+            print("-" * 40)
+            for game in games:
+                event_id = game.get("eventId", "")
+                away_abbrev = game.get("awayTeam", {}).get("abbreviation", "???")
+                home_abbrev = game.get("homeTeam", {}).get("abbreviation", "???")
+                away_team = game.get("awayTeam", {}).get("teamName", "Unknown")
+                home_team = game.get("homeTeam", {}).get("teamName", "Unknown")
+                status_text = game.get("gameStatusText", "Unknown")
+                game_status = game.get("gameStatus", 0)
+
+                # Format time
+                time_str = "N/A"
+                if game.get("gameTimeLTZ"):
+                    time_str = game["gameTimeLTZ"].strftime("%H:%M %Z")
+
+                # Format score if game has started
+                score_str = ""
+                if game_status in (2, 3):  # In progress or finished
+                    away_score = game.get("awayTeam", {}).get("score", 0)
+                    home_score = game.get("homeTeam", {}).get("score", 0)
+                    score_str = f" | {away_score}-{home_score}"
+
+                # Format odds if available
+                odds_str = ""
+                if game.get("odds"):
+                    odds = game["odds"]
+                    spread = odds.get("spread", 0)
+                    over_under = odds.get("overUnder", 0)
+                    if spread or over_under:
+                        odds_str = f" | Spread: {spread:+.1f}, O/U: {over_under}"
+
+                print(
+                    f"  {event_id}: {away_abbrev} @ {home_abbrev} "
+                    f"({away_team} vs {home_team}) | {time_str} | {status_text}{score_str}{odds_str}"
+                )
+                total_games += 1
+            print()
+        else:
+            print(f"Date: {date_str} - No games scheduled\n")
+
+        current += timedelta(days=1)
+
+    print(f"{'=' * 80}")
+    print(f"Total: {total_games} game(s)")
+    print(f"{'=' * 80}\n")
+
+
 def main() -> int:
     """Main entry point."""
     arg_parser = argparse.ArgumentParser(
         description="NFL Game Collector - Orchestrates data collection for NFL games"
     )
-    arg_parser.add_argument(
-        "--date",
+    subparsers = arg_parser.add_subparsers(dest="command", help="Available commands")
+
+    # List games subcommand
+    list_parser = subparsers.add_parser("list", help="List NFL games in a date range")
+    list_parser.add_argument(
+        "--start-date",
         type=str,
         default=None,
-        help="Date to collect games for (YYYY-MM-DD). Default: today",
+        help="Start date (YYYY-MM-DD). Default: today",
     )
-    arg_parser.add_argument(
+    list_parser.add_argument(
+        "--end-date",
+        type=str,
+        default=None,
+        help="End date (YYYY-MM-DD). Default: same as start date",
+    )
+    list_parser.add_argument(
         "--week",
         type=int,
         default=None,
-        help="NFL week number to collect games for (1-18 for regular season)",
+        help="NFL week number to list games for (overrides date range)",
     )
-    arg_parser.add_argument(
+    list_parser.add_argument(
         "--season-type",
         type=int,
         default=2,
         choices=[1, 2, 3],
         help="Season type: 1=preseason, 2=regular, 3=postseason (default: 2)",
     )
-    arg_parser.add_argument(
+    list_parser.add_argument(
+        "--log-level",
+        type=str,
+        default="WARNING",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
+        help="Logging level (default: WARNING)",
+    )
+
+    # Collect subcommand
+    collect_parser = subparsers.add_parser("collect", help="Collect data for NFL games")
+    collect_parser.add_argument(
+        "--date",
+        type=str,
+        default=None,
+        help="Date to collect games for (YYYY-MM-DD). Default: today",
+    )
+    collect_parser.add_argument(
+        "--week",
+        type=int,
+        default=None,
+        help="NFL week number to collect games for (1-18 for regular season)",
+    )
+    collect_parser.add_argument(
+        "--season-type",
+        type=int,
+        default=2,
+        choices=[1, 2, 3],
+        help="Season type: 1=preseason, 2=regular, 3=postseason (default: 2)",
+    )
+    collect_parser.add_argument(
         "--event-id",
         type=str,
         default=None,
         help="Specific ESPN event ID to collect data for",
     )
-    arg_parser.add_argument(
+    collect_parser.add_argument(
         "--base-config",
         type=Path,
         default=Path(__file__).parent.parent / "configs" / "nfl-game.yaml",
         help="Path to base config template (default: configs/nfl-game.yaml)",
     )
-    arg_parser.add_argument(
+    collect_parser.add_argument(
         "--data-dir",
         type=Path,
         default=None,
         help="Data directory for date-organized structure",
     )
-    arg_parser.add_argument(
+    collect_parser.add_argument(
         "--pre-start-hours",
         type=float,
         default=1.0,
         help="Hours before kickoff to start trial (default: 1.0)",
     )
-    arg_parser.add_argument(
+    collect_parser.add_argument(
         "--check-interval",
         type=float,
         default=60.0,
         help="Interval in seconds to check game status (default: 60.0)",
     )
-    arg_parser.add_argument(
+    collect_parser.add_argument(
         "--log-level",
         type=str,
         default="INFO",
         choices=["DEBUG", "INFO", "WARNING", "ERROR"],
         help="Logging level (default: INFO)",
     )
-    arg_parser.add_argument(
-        "--list-only",
-        action="store_true",
-        help="Only list games, don't start collection",
-    )
-    arg_parser.add_argument(
+    collect_parser.add_argument(
         "--oss-upload",
         action="store_true",
         help="Upload files to OSS after trial completion",
     )
-    arg_parser.add_argument(
+    collect_parser.add_argument(
         "--oss-bucket",
         type=str,
         default=None,
         help="Override OSS bucket name (default: from DOJOZERO_OSS_BUCKET env var)",
     )
-    arg_parser.add_argument(
+    collect_parser.add_argument(
         "--oss-prefix",
         type=str,
         default=None,
@@ -1204,91 +1335,106 @@ def main() -> int:
 
     args = arg_parser.parse_args()
 
+    # Handle no command
+    if args.command is None:
+        arg_parser.print_help()
+        return 0
+
     logging.basicConfig(
         level=getattr(logging, args.log_level.upper()),
         format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
         datefmt="%Y-%m-%d %H:%M:%S",
     )
 
-    # List-only mode: just show games
-    if args.list_only:
+    # Handle list command
+    if args.command == "list":
         if args.week:
+            # List by week
             asyncio.run(
                 get_nfl_games_for_week(args.week, args.season_type, print_games=True)
             )
         else:
-            game_date = args.date if args.date else datetime.now()
-            asyncio.run(get_nfl_games_for_date(game_date, print_games=True))
+            # List by date range
+            asyncio.run(
+                list_games_in_range(
+                    start_date=args.start_date,
+                    end_date=args.end_date,
+                )
+            )
         return 0
 
-    # Validate base config
-    if not args.base_config.exists():
-        logger.error("Base config file not found: %s", args.base_config)
-        logger.info(
-            "Please create an NFL config template at %s or specify --base-config",
-            args.base_config,
-        )
-        return 1
+    # Handle collect command
+    if args.command == "collect":
+        # Validate base config
+        if not args.base_config.exists():
+            logger.error("Base config file not found: %s", args.base_config)
+            logger.info(
+                "Please create an NFL config template at %s or specify --base-config",
+                args.base_config,
+            )
+            return 1
 
-    try:
-        if args.event_id:
-            managers = asyncio.run(
-                collect_game_for_event_id(
-                    event_id=args.event_id,
-                    base_config=args.base_config,
-                    pre_start_hours=args.pre_start_hours,
-                    check_interval_seconds=args.check_interval,
-                    data_dir=args.data_dir,
-                    log_level=args.log_level,
-                    oss_upload=args.oss_upload,
-                    oss_bucket=args.oss_bucket,
-                    oss_prefix=args.oss_prefix,
+        try:
+            if args.event_id:
+                managers = asyncio.run(
+                    collect_game_for_event_id(
+                        event_id=args.event_id,
+                        base_config=args.base_config,
+                        pre_start_hours=args.pre_start_hours,
+                        check_interval_seconds=args.check_interval,
+                        data_dir=args.data_dir,
+                        log_level=args.log_level,
+                        oss_upload=args.oss_upload,
+                        oss_bucket=args.oss_bucket,
+                        oss_prefix=args.oss_prefix,
+                    )
                 )
-            )
-        elif args.week:
-            managers = asyncio.run(
-                collect_games_for_week(
-                    week=args.week,
-                    base_config=args.base_config,
-                    season_type=args.season_type,
-                    pre_start_hours=args.pre_start_hours,
-                    check_interval_seconds=args.check_interval,
-                    data_dir=args.data_dir,
-                    log_level=args.log_level,
-                    oss_upload=args.oss_upload,
-                    oss_bucket=args.oss_bucket,
-                    oss_prefix=args.oss_prefix,
+            elif args.week:
+                managers = asyncio.run(
+                    collect_games_for_week(
+                        week=args.week,
+                        base_config=args.base_config,
+                        season_type=args.season_type,
+                        pre_start_hours=args.pre_start_hours,
+                        check_interval_seconds=args.check_interval,
+                        data_dir=args.data_dir,
+                        log_level=args.log_level,
+                        oss_upload=args.oss_upload,
+                        oss_bucket=args.oss_bucket,
+                        oss_prefix=args.oss_prefix,
+                    )
                 )
-            )
-        else:
-            game_date = args.date if args.date else datetime.now()
-            managers = asyncio.run(
-                collect_games_for_date(
-                    game_date=game_date,
-                    base_config=args.base_config,
-                    pre_start_hours=args.pre_start_hours,
-                    check_interval_seconds=args.check_interval,
-                    data_dir=args.data_dir,
-                    log_level=args.log_level,
-                    oss_upload=args.oss_upload,
-                    oss_bucket=args.oss_bucket,
-                    oss_prefix=args.oss_prefix,
+            else:
+                game_date = args.date if args.date else datetime.now()
+                managers = asyncio.run(
+                    collect_games_for_date(
+                        game_date=game_date,
+                        base_config=args.base_config,
+                        pre_start_hours=args.pre_start_hours,
+                        check_interval_seconds=args.check_interval,
+                        data_dir=args.data_dir,
+                        log_level=args.log_level,
+                        oss_upload=args.oss_upload,
+                        oss_bucket=args.oss_bucket,
+                        oss_prefix=args.oss_prefix,
+                    )
                 )
-            )
 
-        if not managers:
-            logger.info("No games to collect")
+            if not managers:
+                logger.info("No games to collect")
+                return 0
+
+            asyncio.run(run_collection(managers))
             return 0
 
-        asyncio.run(run_collection(managers))
-        return 0
+        except KeyboardInterrupt:
+            logger.info("Interrupted by user")
+            return 130
+        except Exception as e:
+            logger.error("Fatal error: %s", e, exc_info=True)
+            return 1
 
-    except KeyboardInterrupt:
-        logger.info("Interrupted by user")
-        return 130
-    except Exception as e:
-        logger.error("Fatal error: %s", e, exc_info=True)
-        return 1
+    return 0
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
So we don't have to run full collection to get game info.

```bash
% uv run python tools/nba_game_collector.py list       

================================================================================
NBA Games from 2026-01-15 to 2026-01-15
================================================================================

Date: 2026-01-15 (9 game(s))
----------------------------------------
  0022500578: MEM @ ORL (Grizzlies vs Magic) | 11:00 PST | Final | 111-118
  0022500579: PHX @ DET (Suns vs Pistons) | 16:00 PST | Final | 105-108
  0022500580: BOS @ MIA (Celtics vs Heat) | 16:30 PST | Final | 119-114
  0022500581: OKC @ HOU (Thunder vs Rockets) | 16:30 PST | Final | 111-91
  0022500582: MIL @ SAS (Bucks vs Spurs) | 17:00 PST | Final | 101-119
  0022500583: UTA @ DAL (Jazz vs Mavericks) | 17:30 PST | Final | 122-144
  0022500584: NYK @ GSW (Knicks vs Warriors) | 19:00 PST | Final                | 113-126
  0022500585: ATL @ POR (Hawks vs Trail Blazers) | 19:00 PST | Final | 101-117
  0022500586: CHA @ LAL (Hornets vs Lakers) | 19:30 PST | 4th Qtr              | 135-117

================================================================================
Total: 9 game(s)
================================================================================
```