### PR TITLE
filter OddsInfo for agent

### DIFF
--- a/src/dojozero/betting/_broker.py
+++ b/src/dojozero/betting/_broker.py
@@ -2158,7 +2158,7 @@ class BrokerOperator(OperatorBase, Operator[BrokerOperatorConfig]):
             if not event:
                 return "null"
 
-            filtered_event = event.model_copy(deep=True)
+            filtered_event = event.model_copy()
             filtered_event.current_odds = _build_filtered_odds_str(
                 filtered_event,
                 include_moneyline=can_bet_moneyline,

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -2396,10 +2396,278 @@ class TestMultipleSpreadsTotals:
 # =============================================================================
 # Agent Tools Configuration Tests
 # =============================================================================
-
-
 class TestAllowedTools:
     """Test allowed_tools configuration"""
+
+    @pytest_asyncio.fixture
+    async def broker_moneyline_only(self):
+        """Broker that only allows moneyline betting tools."""
+        config: BrokerOperatorConfig = {
+            "actor_id": "test_broker_ml",
+            "initial_balance": "1000.00",
+            "allowed_tools": [
+                "get_balance",
+                "get_event",
+                "place_market_bet_moneyline",
+                "place_limit_bet_moneyline",
+            ],
+        }
+        broker = BrokerOperator(config, trial_id="test-trial")
+        await broker.start()
+        yield broker
+        await broker.stop()
+
+    @pytest_asyncio.fixture
+    async def broker_spread_only(self):
+        """Broker that only allows spread betting tools."""
+        config: BrokerOperatorConfig = {
+            "actor_id": "test_broker_spread",
+            "initial_balance": "1000.00",
+            "allowed_tools": [
+                "get_balance",
+                "get_event",
+                "place_market_bet_spread",
+                "place_limit_bet_spread",
+            ],
+        }
+        broker = BrokerOperator(config, trial_id="test-trial")
+        await broker.start()
+        yield broker
+        await broker.stop()
+
+    @pytest_asyncio.fixture
+    async def broker_total_only(self):
+        """Broker that only allows total betting tools."""
+        config: BrokerOperatorConfig = {
+            "actor_id": "test_broker_total",
+            "initial_balance": "1000.00",
+            "allowed_tools": [
+                "get_balance",
+                "get_event",
+                "place_market_bet_total",
+                "place_limit_bet_total",
+            ],
+        }
+        broker = BrokerOperator(config, trial_id="test-trial")
+        await broker.start()
+        yield broker
+        await broker.stop()
+
+    @pytest_asyncio.fixture
+    async def event_with_all_markets(self, broker, agent):
+        """Helper: broker with agent and a fully initialized event (moneyline + spread + total)."""
+        await broker.register_agents([agent])  # type: ignore[arg-type]
+
+        game_init = StreamEvent(
+            stream_id="stream",
+            payload=GameInitializeEvent(
+                game_id="test_event",
+                home_team="Lakers",
+                away_team="Warriors",
+                game_time=datetime.fromisoformat("2025-12-15T19:00:00"),
+            ),
+            emitted_at=datetime.now(),
+        )
+        await broker.handle_stream_event(game_init)
+
+        odds_payload = create_odds_event_with_spreads_totals(
+            game_id="test_event",
+            home_odds=1.95,
+            away_odds=2.10,
+            spread_updates=[{"spread": -3.5, "home_odds": 1.90, "away_odds": 1.90}],
+            total_updates=[{"total": 220.5, "over_odds": 1.88, "under_odds": 1.88}],
+        )
+        odds_event = StreamEvent(
+            stream_id="stream",
+            payload=odds_payload,
+            emitted_at=datetime.now(),
+        )
+        await broker.handle_stream_event(odds_event)
+        return broker, agent
+
+    async def _setup_full_event(self, broker, agent):
+        """Initialize a fully populated event (moneyline + spread + total) on the given broker."""
+        await broker.register_agents([agent])  # type: ignore[arg-type]
+
+        await broker.handle_stream_event(
+            StreamEvent(
+                stream_id="stream",
+                payload=GameInitializeEvent(
+                    game_id="test_event",
+                    home_team="Lakers",
+                    away_team="Warriors",
+                    game_time=datetime.fromisoformat("2025-12-15T19:00:00"),
+                ),
+                emitted_at=datetime.now(),
+            )
+        )
+        await broker.handle_stream_event(
+            StreamEvent(
+                stream_id="stream",
+                payload=create_odds_event_with_spreads_totals(
+                    game_id="test_event",
+                    home_odds=1.95,
+                    away_odds=2.10,
+                    spread_updates=[
+                        {"spread": -3.5, "home_odds": 1.90, "away_odds": 1.90}
+                    ],
+                    total_updates=[
+                        {"total": 220.5, "over_odds": 1.88, "under_odds": 1.88}
+                    ],
+                ),
+                emitted_at=datetime.now(),
+            )
+        )
+
+    def _parse_tool_json_response(self, tool_response):
+        """Extract JSON payload from a ToolResponse."""
+        import json
+
+        assert tool_response.content, "ToolResponse.content should not be empty"
+
+        text_parts = [
+            item["text"] for item in tool_response.content if item.get("type") == "text"
+        ]
+        assert text_parts, f"No text content found in tool response: {tool_response}"
+
+        return json.loads("".join(text_parts))
+
+    # ------------------------------------------------------------------
+    # get_event filtering tests
+    # ------------------------------------------------------------------
+
+    async def test_get_event_moneyline_only_hides_spread_and_total(
+        self, broker_moneyline_only, agent
+    ):
+        """get_event should omit spread_lines and total_lines when only moneyline tools are allowed."""
+        await self._setup_full_event(broker_moneyline_only, agent)
+
+        tools = broker_moneyline_only.agent_tools(agent.actor_id)
+        get_event_tool = next(t for t in tools if t.__name__ == "get_event")
+
+        result = self._parse_tool_json_response(await get_event_tool())
+
+        # Moneyline fields must be present
+        assert result["home_probability"] is not None
+        assert result["away_probability"] is not None
+
+        # Spread and total fields must be absent
+        assert "spread_lines" not in result
+        assert "total_lines" not in result
+
+    async def test_get_event_moneyline_only_current_odds_has_no_spread_or_total(
+        self, broker_moneyline_only, agent
+    ):
+        """current_odds should only contain moneyline lines when only moneyline tools are allowed."""
+        await self._setup_full_event(broker_moneyline_only, agent)
+
+        tools = broker_moneyline_only.agent_tools(agent.actor_id)
+        get_event_tool = next(t for t in tools if t.__name__ == "get_event")
+
+        result = self._parse_tool_json_response(await get_event_tool())
+
+        current_odds = result.get("current_odds", "")
+        assert current_odds is not None
+        assert "Home:" in current_odds
+        assert "Away:" in current_odds
+        assert "Spread:" not in current_odds
+        assert "Total:" not in current_odds
+
+    async def test_get_event_spread_only_hides_moneyline_and_total(
+        self, broker_spread_only, agent
+    ):
+        """get_event should omit home_probability, away_probability and total_lines when only spread tools are allowed."""
+        await self._setup_full_event(broker_spread_only, agent)
+
+        tools = broker_spread_only.agent_tools(agent.actor_id)
+        get_event_tool = next(t for t in tools if t.__name__ == "get_event")
+
+        result = self._parse_tool_json_response(await get_event_tool())
+
+        # Spread fields must be present
+        assert "spread_lines" in result
+        assert len(result["spread_lines"]) > 0
+
+        # Moneyline and total fields must be absent
+        assert "home_probability" not in result
+        assert "away_probability" not in result
+        assert "total_lines" not in result
+
+    async def test_get_event_spread_only_current_odds_has_no_moneyline_or_total(
+        self, broker_spread_only, agent
+    ):
+        """current_odds should only contain spread lines when only spread tools are allowed."""
+        await self._setup_full_event(broker_spread_only, agent)
+
+        tools = broker_spread_only.agent_tools(agent.actor_id)
+        get_event_tool = next(t for t in tools if t.__name__ == "get_event")
+
+        result = self._parse_tool_json_response(await get_event_tool())
+
+        current_odds = result.get("current_odds", "")
+        assert current_odds is not None
+        assert "- Spread:" in current_odds
+        assert "- Home:" not in current_odds
+        assert "- Away:" not in current_odds
+        assert "- Total:" not in current_odds
+
+    async def test_get_event_total_only_hides_moneyline_and_spread(
+        self, broker_total_only, agent
+    ):
+        """get_event should omit home_probability, away_probability and spread_lines when only total tools are allowed."""
+        await self._setup_full_event(broker_total_only, agent)
+
+        tools = broker_total_only.agent_tools(agent.actor_id)
+        get_event_tool = next(t for t in tools if t.__name__ == "get_event")
+
+        result = self._parse_tool_json_response(await get_event_tool())
+
+        # Total fields must be present
+        assert "total_lines" in result
+        assert len(result["total_lines"]) > 0
+
+        # Moneyline and spread fields must be absent
+        assert "home_probability" not in result
+        assert "away_probability" not in result
+        assert "spread_lines" not in result
+
+    async def test_get_event_total_only_current_odds_has_no_moneyline_or_spread(
+        self, broker_total_only, agent
+    ):
+        """current_odds should only contain total lines when only total tools are allowed."""
+        await self._setup_full_event(broker_total_only, agent)
+
+        tools = broker_total_only.agent_tools(agent.actor_id)
+        get_event_tool = next(t for t in tools if t.__name__ == "get_event")
+
+        result = self._parse_tool_json_response(await get_event_tool())
+
+        current_odds = result.get("current_odds", "")
+        assert current_odds is not None
+        assert "Total:" in current_odds
+        assert "Home:" not in current_odds
+        assert "Away:" not in current_odds
+        assert "Spread:" not in current_odds
+
+    async def test_get_event_all_tools_shows_all_markets(self, event_with_all_markets):
+        """get_event should expose all markets when no tool restriction is set."""
+        broker, agent = event_with_all_markets
+
+        tools = broker.agent_tools(agent.actor_id)
+        get_event_tool = next(t for t in tools if t.__name__ == "get_event")
+
+        result = self._parse_tool_json_response(await get_event_tool())
+
+        assert result["home_probability"] is not None
+        assert result["away_probability"] is not None
+        assert "spread_lines" in result and len(result["spread_lines"]) > 0
+        assert "total_lines" in result and len(result["total_lines"]) > 0
+
+        current_odds = result.get("current_odds", "")
+        assert "Home:" in current_odds
+        assert "Away:" in current_odds
+        assert "Spread:" in current_odds
+        assert "Total:" in current_odds
 
     @pytest_asyncio.fixture
     async def broker_with_limited_tools(self):


### PR DESCRIPTION
filter get_event, the OddsInfo shown to the agent should include only the odds information for the prediction type currently being made (e.g., spread) under both the passed event and current_odds. This is to prevent the agent from seeing multiple types of odds information and getting confused, especially when there is no corresponding tool available for those other odds types.

now it's like:

system: {
    "type": "tool_result",
    "id": "call_bdea5fd9baae4746b242b3e7",
    "name": "get_event",
    "output": [
        {
            "type": "text",
            "text": "{\"event_id\":\"401810753\",\"home_team\":\"LA Clippers\",\"away_team\":\"Indiana Pacers\",\"game_time\":\"2026-03-05T03:30:00Z\",\"status\":\"SCHEDULED\",\"home_probability\":\"0.835\",\"away_probability\":\"0.165\",\"last_odds_update\":\"2026-03-21T21:41:37.359357\",\"current_odds\":\"- Home: 1.20 (83.5% implied probability)\\n- Away: 6.06 (16.5% implied probability)\",\"betting_closed_at\":null,\"can_bet\":true}"
        }
    ]
}