### PR TITLE
Add event throttle to BettingAgent to cap LLM API costs

### DIFF
--- a/src/dojozero/betting/_agent.py
+++ b/src/dojozero/betting/_agent.py
@@ -721,6 +721,13 @@ class BettingAgent(AgentBase, Agent[BettingAgentConfig]):
 
     async def stop(self) -> None:
         """Stop the agent."""
+        if self._cooldown_task is not None and not self._cooldown_task.done():
+            self._cooldown_task.cancel()
+            try:
+                await self._cooldown_task
+            except asyncio.CancelledError:
+                pass
+            self._cooldown_task = None
         logger.info(
             "agent '%s' stopping after %d events", self.actor_id, self._event_count
         )

--- a/tests/test_agent_event_throttle.py
+++ b/tests/test_agent_event_throttle.py
@@ -209,3 +209,20 @@ async def test_memory_token_threshold_default():
     """Verify the memory compression threshold is set to ~80% of 128K."""
     agent = _make_agent()
     assert agent._memory_token_threshold == 102400
+
+
+@pytest.mark.asyncio
+async def test_stop_cancels_cooldown_task():
+    """Stopping the agent should cancel any pending cooldown task."""
+    agent = _make_agent(min_event_interval=600.0)
+
+    with patch.object(agent, "_process_events_with_retry", new_callable=AsyncMock):
+        await agent.handle_stream_event(_event(0))
+        await agent.handle_stream_event(_event(1))
+
+    assert agent._cooldown_task is not None
+    assert not agent._cooldown_task.done()
+
+    await agent.stop()
+
+    assert agent._cooldown_task is None


### PR DESCRIPTION
The removal of the odds-update cooldown in #140 (commit 0649066, Mar 13) left agents with no rate-limiting on LLM calls, causing ~50 model queries per minute and ~$200/day on Claude alone.

Changes:
- Add per-agent event throttle (_min_event_interval = 180s) that queues events during cooldown and batch-processes them when the window expires. A background task ensures queued events are never lost.
- Raise memory compression threshold from 9K to 102,400 tokens (80% of 128K context window) so LLM-based memory offload fires far less often.
- Extract _drain_event_queue() helper shared by handle_stream_event and the cooldown task to avoid code duplication.
- Add 7 unit tests covering throttle behavior (immediate first event, cooldown queuing, batch drain, no duplicate tasks, etc.).

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>