### PR TITLE
fix: deep copy scenario config to prevent shared persistence file across trials

### DIFF
--- a/src/dojozero/core/_metadata.py
+++ b/src/dojozero/core/_metadata.py
@@ -11,8 +11,8 @@ Usage:
         my_field: str
 """
 
-from dataclasses import dataclass
-from typing import TypeVar
+from dataclasses import dataclass, fields
+from typing import Any, TypeVar
 
 
 @dataclass(slots=True)
@@ -30,6 +30,35 @@ class BaseTrialMetadata:
     hub_id: str
     persistence_file: str
     store_types: tuple[str, ...]
+
+    def get(self, key: str, default: Any = None) -> Any:
+        """Dict-like access for backward compatibility with code that
+        treats metadata as a plain dict."""
+        if key in {f.name for f in fields(self)}:
+            return getattr(self, key)
+        return default
+
+    def __contains__(self, key: object) -> bool:
+        """Support ``key in metadata`` checks."""
+        return isinstance(key, str) and key in {f.name for f in fields(self)}
+
+    def __getitem__(self, key: str) -> Any:
+        """Support ``metadata["key"]`` access."""
+        if key in {f.name for f in fields(self)}:
+            return getattr(self, key)
+        raise KeyError(key)
+
+    def __iter__(self):
+        """Support ``for key in metadata`` iteration over field names."""
+        return iter(f.name for f in fields(self))
+
+    def items(self):
+        """Support ``dict(metadata.items())`` and dict-like iteration."""
+        return ((f.name, getattr(self, f.name)) for f in fields(self))
+
+    def keys(self):
+        """Return field names."""
+        return (f.name for f in fields(self))
 
 
 # TypeVar for generic TrialSpec and StoreFactory

--- a/src/dojozero/dashboard_server/_scheduler.py
+++ b/src/dojozero/dashboard_server/_scheduler.py
@@ -9,6 +9,7 @@ Handles automatic scheduling of trials based on registered trial sources:
 """
 
 import asyncio
+import copy
 import hashlib
 import json
 import logging
@@ -592,7 +593,7 @@ class ScheduleManager:
                 continue
 
             # Build config for this game
-            config = dict(scenario_config or {})
+            config = copy.deepcopy(scenario_config or {})
 
             # Add game-specific config (both NBA and NFL use espn_game_id)
             config["espn_game_id"] = game.game_id
@@ -964,8 +965,8 @@ class ScheduleManager:
                 )
                 continue
 
-            # Build config for this game
-            game_config = dict(config.scenario_config)
+            # Build config for this game (deep copy to avoid shared nested dicts)
+            game_config = copy.deepcopy(config.scenario_config)
 
             # Add game-specific config (both NBA and NFL use espn_game_id)
             game_config["espn_game_id"] = game.game_id

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,0 +1,82 @@
+"""Tests for BaseTrialMetadata dict-like access compatibility."""
+
+from dojozero.betting._metadata import BettingTrialMetadata
+
+
+def _make_metadata() -> BettingTrialMetadata:
+    return BettingTrialMetadata(
+        hub_id="test_hub",
+        persistence_file="test.jsonl",
+        store_types=("nba",),
+        sample="nba",
+        sport_type="nba",
+        espn_game_id="401810490",
+        event_types=("event.nba_game_update",),
+        home_tricode="LAL",
+        away_tricode="BOS",
+        home_team_name="Los Angeles Lakers",
+        away_team_name="Boston Celtics",
+        game_date="2026-03-24",
+    )
+
+
+class TestMetadataDictCompat:
+    """Ensure metadata dataclass supports dict-like access patterns."""
+
+    def test_get_existing_field(self) -> None:
+        m = _make_metadata()
+        assert m.get("espn_game_id") == "401810490"
+        assert m.get("sport_type") == "nba"
+
+    def test_get_missing_field_returns_default(self) -> None:
+        m = _make_metadata()
+        assert m.get("nonexistent") is None
+        assert m.get("nonexistent", "fallback") == "fallback"
+
+    def test_get_base_class_field(self) -> None:
+        m = _make_metadata()
+        assert m.get("hub_id") == "test_hub"
+        assert m.get("persistence_file") == "test.jsonl"
+
+    def test_contains(self) -> None:
+        m = _make_metadata()
+        assert "espn_game_id" in m
+        assert "sport_type" in m
+        assert "nonexistent" not in m
+
+    def test_getitem(self) -> None:
+        m = _make_metadata()
+        assert m["espn_game_id"] == "401810490"
+        assert m["hub_id"] == "test_hub"
+
+    def test_getitem_missing_raises_keyerror(self) -> None:
+        m = _make_metadata()
+        try:
+            m["nonexistent"]
+            assert False, "Should have raised KeyError"
+        except KeyError:
+            pass
+
+    def test_dict_conversion(self) -> None:
+        m = _make_metadata()
+        d = dict(m)
+        assert d["espn_game_id"] == "401810490"
+        assert d["sport_type"] == "nba"
+        assert d["hub_id"] == "test_hub"
+        assert len(d) == len(list(m.keys()))
+
+    def test_iter(self) -> None:
+        m = _make_metadata()
+        field_names = list(m)
+        assert "espn_game_id" in field_names
+        assert "hub_id" in field_names
+
+    def test_items(self) -> None:
+        m = _make_metadata()
+        items = dict(m.items())
+        assert items["espn_game_id"] == "401810490"
+
+    def test_optional_field_defaults(self) -> None:
+        m = _make_metadata()
+        assert m.get("market_url") is None
+        assert m.get("nba_poll_intervals") is None


### PR DESCRIPTION


  Shallow copy of scenario_config caused all scheduled trials to share the same
  hub dict, so each game's persistence_file overwrote the previous one. This meant
  all trials wrote to the same JSONL file; when the first game completed and closed
  the handle, remaining trials crashed — resulting in only 1 completed game per day.

  Also adds dict-like compat methods (.get, [], in, dict()) to BaseTrialMetadata
  so consumers that treat metadata as a plain dict don't crash with
  "'BettingTrialMetadata' object has no attribute 'get'".