### PR TITLE
Replace max_concurrent_games with max_daily_games to cap total games per day

### DIFF
--- a/deploy/DEPLOYMENT.md
+++ b/deploy/DEPLOYMENT.md
@@ -182,7 +182,7 @@ source_id: nba-moneyline-source
 sport_type: nba
 config:
   scenario_name: nba
-  max_concurrent_games: 0    # 0 = unlimited
+  max_daily_games: 0    # 0 = unlimited
   personas: [degen, mystic, pundit, shark, sheep, whale]
   llm_config_path: agents/llms/all.yaml
 ```

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       - ../outputs:/app/outputs
       - ../data:/app/data
       - ../trial_sources:/app/trial_sources:ro
-      - dojozero-nba-schedules:/app/.dojozero
+      - dojozero-nba-store:/app/dojozero-store
     command: >
       dojo0 serve
       --host 0.0.0.0
@@ -68,7 +68,7 @@ services:
       - ../outputs:/app/outputs
       - ../data:/app/data
       - ../trial_sources:/app/trial_sources:ro
-      - dojozero-nfl-schedules:/app/.dojozero
+      - dojozero-nfl-store:/app/dojozero-store
     command: >
       dojo0 serve
       --host 0.0.0.0
@@ -107,7 +107,7 @@ services:
       - ../outputs:/app/outputs
       - ../data:/app/data
       - ../trial_sources:/app/trial_sources:ro
-      - dojozero-ncaa-schedules:/app/.dojozero
+      - dojozero-ncaa-store:/app/dojozero-store
     command: >
       dojo0 serve
       --host 0.0.0.0
@@ -128,9 +128,9 @@ services:
       start_period: 10s
 
 volumes:
-  dojozero-nba-schedules:
-    name: dojozero-nba-schedules
-  dojozero-nfl-schedules:
-    name: dojozero-nfl-schedules
-  dojozero-ncaa-schedules:
-    name: dojozero-ncaa-schedules
+  dojozero-nba-store:
+    name: dojozero-nba-store
+  dojozero-nfl-store:
+    name: dojozero-nfl-store
+  dojozero-ncaa-store:
+    name: dojozero-ncaa-store

--- a/src/dojozero/dashboard_server/_scheduler.py
+++ b/src/dojozero/dashboard_server/_scheduler.py
@@ -58,7 +58,7 @@ class TrialSourceConfig(BaseModel):
         data_dir: Base directory for persistence files. If set, files are
             created at {data_dir}/{game_date}/{game_id}.jsonl
         sync_interval_seconds: How often to sync with ESPN API for new games
-        max_concurrent_games: Maximum number of games to schedule concurrently
+        max_daily_games: Maximum number of games to schedule per day
             for this source. 0 means unlimited (default).
     """
 
@@ -71,7 +71,7 @@ class TrialSourceConfig(BaseModel):
     sync_interval_seconds: float = (
         300.0  # How often to sync with external APIs (5 min default)
     )
-    max_concurrent_games: int = 0  # 0 = unlimited
+    max_daily_games: int = 0  # 0 = unlimited
 
 
 @dataclass
@@ -778,9 +778,7 @@ class ScheduleManager:
         agent_personas = [a.get("persona", a.get("id", "?")) for a in agents]
         llm_paths = {a.get("llm_config_path", "inline") for a in agents}
         max_games_str = (
-            str(config.max_concurrent_games)
-            if config.max_concurrent_games > 0
-            else "unlimited"
+            str(config.max_daily_games) if config.max_daily_games > 0 else "unlimited"
         )
         LOGGER.info(
             "Registered trial source '%s' for %s: "
@@ -888,30 +886,26 @@ class ScheduleManager:
             LOGGER.error("Error fetching games for source %s: %s", source.source_id, e)
             return []
 
-        # Check max_concurrent_games limit
-        max_games = config.max_concurrent_games
+        # Check max_daily_games limit (count all games scheduled today for this source)
+        max_games = config.max_daily_games
         if max_games > 0:
-            active_count = sum(
+            today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+            daily_count = sum(
                 1
                 for sid, gid in self._scheduled_events
                 if sid == source.source_id
                 and self._schedules.get(self._scheduled_events[(sid, gid)])
-                and self._schedules[self._scheduled_events[(sid, gid)]].phase
-                in (
-                    ScheduledTrialPhase.WAITING,
-                    ScheduledTrialPhase.LAUNCHING,
-                    ScheduledTrialPhase.RUNNING,
-                    ScheduledTrialPhase.MONITORING,
-                )
+                and self._schedules[self._scheduled_events[(sid, gid)]].game_date
+                == today
             )
-            remaining_slots = max_games - active_count
+            remaining_slots = max_games - daily_count
             if remaining_slots <= 0:
                 LOGGER.info(
-                    "Source '%s': max_concurrent_games=%d reached "
-                    "(%d active), skipping new games",
+                    "Source '%s': max_daily_games=%d reached "
+                    "(%d today), skipping new games",
                     source.source_id,
                     max_games,
-                    active_count,
+                    daily_count,
                 )
                 return []
         else:
@@ -953,11 +947,10 @@ class ScheduleManager:
             if (source.source_id, game.game_id) in self._scheduled_events:
                 continue
 
-            # Enforce max_concurrent_games limit
+            # Enforce max_daily_games limit
             if max_games > 0 and remaining_slots <= 0:
                 LOGGER.info(
-                    "Source '%s': skipping game %s (%s) — "
-                    "max_concurrent_games=%d reached",
+                    "Source '%s': skipping game %s (%s) — max_daily_games=%d reached",
                     source.source_id,
                     game.game_id,
                     game.short_name,

--- a/src/dojozero/dashboard_server/_server.py
+++ b/src/dojozero/dashboard_server/_server.py
@@ -115,7 +115,7 @@ class TrialSourceConfigRequest(BaseModel):
     check_interval_seconds: float = 60.0
     auto_stop_on_completion: bool = True
     data_dir: str | None = None
-    max_concurrent_games: int = 0
+    max_daily_games: int = 0
 
 
 class TrialSourceRequest(BaseModel):
@@ -360,7 +360,7 @@ def create_dashboard_app(
                     sync_interval_seconds=config_data.get(
                         "sync_interval_seconds", 300.0
                     ),
-                    max_concurrent_games=config_data.get("max_concurrent_games", 0),
+                    max_daily_games=config_data.get("max_daily_games", 0),
                 )
 
                 # Update config if already registered (YAML is authoritative)
@@ -1110,7 +1110,7 @@ def create_dashboard_app(
                 check_interval_seconds=request.config.check_interval_seconds,
                 auto_stop_on_completion=request.config.auto_stop_on_completion,
                 data_dir=request.config.data_dir,
-                max_concurrent_games=request.config.max_concurrent_games,
+                max_daily_games=request.config.max_daily_games,
             )
 
             source = state.schedule_manager.register_source(

--- a/src/dojozero/dashboard_server/_types.py
+++ b/src/dojozero/dashboard_server/_types.py
@@ -156,7 +156,7 @@ class TrialSourceConfigDict(TypedDict, total=False):
     auto_stop_on_completion: bool
     data_dir: str | None
     sync_interval_seconds: float
-    max_concurrent_games: int
+    max_daily_games: int
 
 
 class InitialTrialSourceDict(TypedDict):

--- a/trial_sources/daily/nba.yaml
+++ b/trial_sources/daily/nba.yaml
@@ -4,6 +4,6 @@ source_id: nba-moneyline-source
 sport_type: nba
 config:
   scenario_name: nba
-  max_concurrent_games: 1
+  max_daily_games: 1
   personas: [degen]
   llm_config_path: agents/llms/claude.yaml

--- a/trial_sources/daily/ncaa.yaml
+++ b/trial_sources/daily/ncaa.yaml
@@ -4,6 +4,6 @@ source_id: ncaa-moneyline-source
 sport_type: ncaa
 config:
   scenario_name: ncaa
-  max_concurrent_games: 1
+  max_daily_games: 1
   personas: [degen]
   llm_config_path: agents/llms/claude.yaml

--- a/trial_sources/daily/nfl.yaml
+++ b/trial_sources/daily/nfl.yaml
@@ -4,6 +4,6 @@ source_id: nfl-moneyline-source
 sport_type: nfl
 config:
   scenario_name: nfl
-  max_concurrent_games: 1
+  max_daily_games: 1
   personas: [degen]
   llm_config_path: agents/llms/claude.yaml

--- a/trial_sources/pre/nba.yaml
+++ b/trial_sources/pre/nba.yaml
@@ -4,6 +4,6 @@ source_id: nba-moneyline-source
 sport_type: nba
 config:
   scenario_name: nba
-  max_concurrent_games: 1
+  max_daily_games: 2
   personas: [degen, mystic, pundit, shark, sheep, whale]
   llm_config_path: agents/llms/all.yaml

--- a/trial_sources/pre/ncaa.yaml
+++ b/trial_sources/pre/ncaa.yaml
@@ -4,6 +4,6 @@ source_id: ncaa-moneyline-source
 sport_type: ncaa
 config:
   scenario_name: ncaa
-  max_concurrent_games: 1
+  max_daily_games: 2
   personas: [degen, mystic, pundit, shark, sheep, whale]
   llm_config_path: agents/llms/all.yaml

--- a/trial_sources/pre/nfl.yaml
+++ b/trial_sources/pre/nfl.yaml
@@ -4,6 +4,6 @@ source_id: nfl-moneyline-source
 sport_type: nfl
 config:
   scenario_name: nfl
-  max_concurrent_games: 1
+  max_daily_games: 2
   personas: [degen, mystic, pundit, shark, sheep, whale]
   llm_config_path: agents/llms/all.yaml

--- a/trial_sources/prod/nba.yaml
+++ b/trial_sources/prod/nba.yaml
@@ -4,6 +4,6 @@ source_id: nba-moneyline-source
 sport_type: nba
 config:
   scenario_name: nba
-  max_concurrent_games: 0
+  max_daily_games: 0
   personas: [degen, mystic, pundit, shark, sheep, whale]
   llm_config_path: agents/llms/all.yaml

--- a/trial_sources/prod/ncaa.yaml
+++ b/trial_sources/prod/ncaa.yaml
@@ -4,6 +4,6 @@ source_id: ncaa-moneyline-source
 sport_type: ncaa
 config:
   scenario_name: ncaa
-  max_concurrent_games: 0
+  max_daily_games: 0
   personas: [degen, mystic, pundit, shark, sheep, whale]
   llm_config_path: agents/llms/all.yaml

--- a/trial_sources/prod/nfl.yaml
+++ b/trial_sources/prod/nfl.yaml
@@ -4,6 +4,6 @@ source_id: nfl-moneyline-source
 sport_type: nfl
 config:
   scenario_name: nfl
-  max_concurrent_games: 0
+  max_daily_games: 0
   personas: [degen, mystic, pundit, shark, sheep, whale]
   llm_config_path: agents/llms/all.yaml


### PR DESCRIPTION
  max_concurrent_games only limited how many trials ran simultaneously — games
  would still get scheduled sequentially throughout the day. max_daily_games
  counts all games scheduled today (regardless of phase) so daily=1 means
  exactly 1 game per day, not 1 at a time.

  Also fix docker-compose volume mounts: the store volumes were mounted at
  /app/.dojozero but the app writes to /app/dojozero-store, so schedule state
  was never persisted across container restarts.

  Tier configs: daily=1, pre=2, prod=unlimited