### PR TITLE
feat: OSS-backed trial storage with unified outputs/trials/ cache

### DIFF
--- a/packages/dojozero/src/dojozero/cli.py
+++ b/packages/dojozero/src/dojozero/cli.py
@@ -399,6 +399,13 @@ def _build_parser() -> argparse.ArgumentParser:
         help=f"Directory for filesystem store (default: {DEFAULT_STORE_DIRECTORY}).",
     )
     serve_parser.add_argument(
+        "--output-dir",
+        dest="output_dir",
+        type=Path,
+        default=Path("outputs"),
+        help="Directory for trial output/event files (default: outputs).",
+    )
+    serve_parser.add_argument(
         "--runtime-provider",
         dest="runtime_provider",
         choices=["local", "ray"],
@@ -2414,6 +2421,7 @@ async def _serve_command(args: argparse.Namespace) -> int:
         auto_resume=auto_resume,
         stale_threshold_hours=stale_threshold_hours,
         enable_gateway=enable_gateway,
+        output_dir=args.output_dir,
         authenticator=authenticator,
         no_scheduler=no_scheduler,
         cluster_config=cluster_config,

--- a/packages/dojozero/src/dojozero/dashboard_server/_scheduler.py
+++ b/packages/dojozero/src/dojozero/dashboard_server/_scheduler.py
@@ -57,8 +57,9 @@ class TrialSourceConfig(BaseModel):
         pre_start_hours: Hours before game start to launch the trial
         check_interval_seconds: Interval for checking game status
         auto_stop_on_completion: Whether to stop trial when game finishes
-        data_dir: Base directory for persistence files. If set, files are
-            created at {data_dir}/{game_date}/{game_id}.jsonl
+        output_dir: Per-source override for output directory. If set, persistence
+            files are created at {output_dir}/{game_date}/{game_id}.jsonl.
+            Overrides the server-level --output-dir.
         sync_interval_seconds: How often to sync with ESPN API for new games
         max_daily_games: Maximum number of games to schedule per day
             for this source. 0 means unlimited (default).
@@ -69,7 +70,7 @@ class TrialSourceConfig(BaseModel):
     pre_start_hours: float = 2.0
     check_interval_seconds: float = 60.0
     auto_stop_on_completion: bool = True
-    data_dir: str | None = None
+    output_dir: str | None = None
     sync_interval_seconds: float = (
         300.0  # How often to sync with external APIs (5 min default)
     )
@@ -409,6 +410,7 @@ class ScheduleManager:
         grace_period_seconds: float = 60.0,  # Safety net (self-stop is primary at 10s)
         peer_registry: "PeerRegistry | None" = None,
         server_id: str | None = None,
+        output_dir: Path | None = None,
     ):
         """Initialize the ScheduleManager.
 
@@ -424,6 +426,8 @@ class ScheduleManager:
                 collection before stopping the trial. Default: 300 (5 minutes)
             peer_registry: Optional peer registry for multi-server trial assignment.
             server_id: This server's identifier (for cluster mode).
+            output_dir: Default output directory for persistence files. Per-source
+                output_dir overrides this if set.
         """
         self._trial_manager = trial_manager
         self._store = store
@@ -432,6 +436,7 @@ class ScheduleManager:
         self._grace_period_seconds = grace_period_seconds
         self._peer_registry: PeerRegistry | None = peer_registry
         self._server_id = server_id
+        self._output_dir = output_dir
 
         # All scheduled trials by ID
         self._schedules: dict[str, ScheduledTrial] = {}
@@ -653,7 +658,7 @@ class ScheduleManager:
         pre_start_hours: float = 2.0,
         check_interval_seconds: float = 60.0,
         auto_stop_on_completion: bool = True,
-        data_dir: str | None = None,
+        output_dir: str | None = None,
         metadata: dict[str, Any] | None = None,
     ) -> list[ScheduledTrial]:
         """Schedule trials for all games on a date or week.
@@ -667,7 +672,7 @@ class ScheduleManager:
             pre_start_hours: Hours before game to start trial
             check_interval_seconds: Interval to check game status
             auto_stop_on_completion: Whether to stop trial when game finishes
-            data_dir: Optional data directory for output files
+            output_dir: Optional output directory override for persistence files
             metadata: Optional metadata
 
         Returns:
@@ -714,8 +719,14 @@ class ScheduleManager:
             schedule_id = self._generate_schedule_id(sport_type, game.game_id)
 
             # Set persistence_file with unique schedule_id to avoid conflicts
-            if data_dir:
-                persistence_file = f"{data_dir}/{game_date}/{schedule_id}.jsonl"
+            # Explicit output_dir param overrides server-level output_dir
+            effective_output_dir = output_dir or (
+                str(self._output_dir) if self._output_dir else None
+            )
+            if effective_output_dir:
+                persistence_file = (
+                    f"{effective_output_dir}/{game_date}/{schedule_id}.jsonl"
+                )
                 config["hub"]["persistence_file"] = persistence_file
 
             # Add game info to metadata using typed structure
@@ -1109,8 +1120,14 @@ class ScheduleManager:
             schedule_id = self._generate_schedule_id(source.sport_type, game.game_id)
 
             # Set persistence_file with unique schedule_id to avoid conflicts
-            if config.data_dir:
-                persistence_file = f"{config.data_dir}/{game_date}/{schedule_id}.jsonl"
+            # Per-source output_dir overrides server-level output_dir
+            effective_output_dir = config.output_dir or (
+                str(self._output_dir) if self._output_dir else None
+            )
+            if effective_output_dir:
+                persistence_file = (
+                    f"{effective_output_dir}/{game_date}/{schedule_id}.jsonl"
+                )
                 game_config["hub"]["persistence_file"] = persistence_file
 
             # Metadata for the trial using typed structure

--- a/packages/dojozero/src/dojozero/dashboard_server/_scheduler.py
+++ b/packages/dojozero/src/dojozero/dashboard_server/_scheduler.py
@@ -1811,6 +1811,15 @@ class ScheduleManager:
             ):
                 self._register_game_result_callback(scheduled)
 
+                # Create symlink in outputs/trials/ for trial-id-indexed lookup
+                pf = scheduled.scenario_config.get("hub", {}).get("persistence_file")
+                if pf and self._output_dir:
+                    from dojozero.dashboard_server._trial_manager import (
+                        ensure_trial_symlink,
+                    )
+
+                    ensure_trial_symlink(self._output_dir, trial_id, Path(pf))
+
             LOGGER.info(
                 "Launched trial '%s' for schedule '%s'",
                 trial_id,

--- a/packages/dojozero/src/dojozero/dashboard_server/_server.py
+++ b/packages/dojozero/src/dojozero/dashboard_server/_server.py
@@ -50,6 +50,8 @@ from dojozero.core._tracing import (
 from dojozero.core._types import RuntimeContext
 from dojozero.dashboard_server._trial_manager import (
     download_trial_from_oss,
+    ensure_trial_symlink,
+    trials_cache_path,
     upload_trial_to_oss,
 )
 
@@ -887,6 +889,7 @@ def create_dashboard_app(
         if "hub" not in builder_config:
             builder_config["hub"] = {}
         builder_config["hub"]["persistence_file"] = str(safe_persistence_file)
+        ensure_trial_symlink(state.output_dir, trial_id, safe_persistence_file)
         LOGGER.debug(
             "Generated persistence_file for trial %s: %s",
             trial_id,
@@ -934,16 +937,15 @@ def create_dashboard_app(
                         event_file = candidate
 
             if event_file is None:
-                # No local file — try OSS, then SLS materialization.
-                output_base = state.output_dir
-                cache_dir = output_base / "backtest_cache"
-                # Cache naming: {trial_id}-{run_id[:8]}.jsonl
-                # 8-char prefix of the 16-hex span_id is sufficient to
-                # avoid collisions while keeping filenames readable.
+                # No local file — try trials cache, OSS, then SLS.
                 run_id = request.backtest.run_id
-                suffix = f"-{run_id[:8]}" if run_id else ""
-                event_file = cache_dir / f"{source_trial_id}{suffix}.jsonl"
+                event_file = trials_cache_path(
+                    state.output_dir, source_trial_id, run_id
+                )
                 materialize_result = None
+                if event_file.is_symlink() and not event_file.exists():
+                    # Dangling symlink — remove so we can write a real file
+                    event_file.unlink()
                 if not event_file.exists():
                     # Try OSS first
                     if download_trial_from_oss(source_trial_id, event_file):
@@ -1273,43 +1275,27 @@ def create_dashboard_app(
         """Download the JSONL event file for a trial.
 
         Resolution order:
-        1. Local persistence_file from trial record metadata
-        2. Local backtest cache file
-        3. OSS download (cached locally)
-        4. Peer proxy (cluster mode — catches in-progress trials)
-        5. SLS materialization (cached locally, then uploaded to OSS)
+        1. Canonical trials cache (includes symlinks to live persistence files)
+        2. OSS download (cached locally)
+        3. Peer proxy (cluster mode — catches in-progress trials)
+        4. SLS materialization (cached locally, then uploaded to OSS)
 
         Returns the JSONL file as a streaming download.
         """
         from fastapi.responses import FileResponse
 
-        # 1. Try local file from trial record metadata
-        # Check backtest_file first (for backtest trials), then persistence_file
+        # 1. Try canonical trials cache (symlinks for live, real files for
+        #    OSS/SLS cached).  Path.exists() follows symlinks transparently.
+        cached_path = trials_cache_path(state.output_dir, trial_id, run_id)
         event_file: Path | None = None
-        record = state.orchestrator.store.get_trial_record(trial_id)
-        if record is not None:
-            for field in ("backtest_file", "persistence_file"):
-                path_str = record.spec.metadata.get(field)
-                if path_str:
-                    candidate = Path(path_str)
-                    if candidate.exists():
-                        event_file = candidate
-                        break
-                    # Try resolving relative to output_dir
-                    if not candidate.is_absolute():
-                        alt = Path(state.output_dir) / candidate
-                        if alt.exists():
-                            event_file = alt
-                            break
-
-        # 2. Try local backtest cache
-        cache_dir = state.output_dir / "backtest_cache"
-        suffix = f"-{run_id[:8]}" if run_id else ""
-        cached_path = cache_dir / f"{trial_id}{suffix}.jsonl"
-        if event_file is None and cached_path.exists():
+        if cached_path.exists():
             event_file = cached_path
+        elif cached_path.is_symlink():
+            # Dangling symlink (target deleted) — remove so later steps
+            # can write a real file at this path.
+            cached_path.unlink()
 
-        # 3. Try OSS
+        # 2. Try OSS
         if event_file is None and download_trial_from_oss(trial_id, cached_path):
             event_file = cached_path
 

--- a/packages/dojozero/src/dojozero/dashboard_server/_server.py
+++ b/packages/dojozero/src/dojozero/dashboard_server/_server.py
@@ -48,6 +48,10 @@ from dojozero.core._tracing import (
     set_sls_log_exporter,
 )
 from dojozero.core._types import RuntimeContext
+from dojozero.dashboard_server._trial_manager import (
+    download_trial_from_oss,
+    upload_trial_to_oss,
+)
 
 from ._cluster import ClusterConfig, LeaderElector, PeerRegistry, create_cluster
 from ._scheduler import SchedulerStore
@@ -165,54 +169,6 @@ def get_server_state(request: Request) -> DashboardServerState:
     if state is None:
         raise RuntimeError("Server not initialized")
     return state
-
-
-def _try_oss_download(trial_id: str, cache_path: Path) -> bool:
-    """Try to download a trial's event file from OSS.
-
-    Returns True if the file was downloaded, False otherwise.
-    Gracefully handles missing deps, config, or network errors.
-    """
-    try:
-        from dojozero.utils.oss import OSSClient
-
-        client = OSSClient.from_env()
-        oss_key = f"trials/{trial_id}/events.jsonl"
-        if client.file_exists(oss_key):
-            cache_path.parent.mkdir(parents=True, exist_ok=True)
-            client.download_file(oss_key, cache_path)
-            LOGGER.info(
-                "Downloaded trial '%s' events from OSS to %s", trial_id, cache_path
-            )
-            return True
-        return False
-    except ImportError:
-        return False
-    except ValueError:
-        return False
-    except Exception as e:
-        LOGGER.debug("OSS download failed for trial '%s': %s", trial_id, e)
-        return False
-
-
-def _try_oss_upload(trial_id: str, local_path: Path) -> None:
-    """Upload a materialized event file to OSS for cross-host caching.
-
-    Fire-and-forget: logs errors but never raises.
-    """
-    try:
-        from dojozero.utils.oss import OSSClient
-
-        client = OSSClient.from_env()
-        oss_key = f"trials/{trial_id}/events.jsonl"
-        client.upload_file(local_path, oss_key)
-        LOGGER.info("Uploaded materialized events for trial '%s' to OSS", trial_id)
-    except ImportError:
-        pass
-    except ValueError:
-        pass
-    except Exception as e:
-        LOGGER.warning("OSS upload failed for trial '%s': %s", trial_id, e)
 
 
 async def _launch_backtest_trial(
@@ -990,7 +946,7 @@ def create_dashboard_app(
                 materialize_result = None
                 if not event_file.exists():
                     # Try OSS first
-                    if _try_oss_download(source_trial_id, event_file):
+                    if download_trial_from_oss(source_trial_id, event_file):
                         backtest_source = "oss"
                     else:
                         # Fall back to SLS materialization
@@ -1006,7 +962,7 @@ def create_dashboard_app(
                             )
                             backtest_source = "sls"
                             # Upload to OSS for cross-host caching
-                            _try_oss_upload(source_trial_id, event_file)
+                            upload_trial_to_oss(source_trial_id, event_file)
                         except Exception as e:
                             LOGGER.error(
                                 "SLS materialization failed for trial '%s': %s",
@@ -1025,7 +981,7 @@ def create_dashboard_app(
                                 status_code=424,
                             )
                 else:
-                    backtest_source = "sls"
+                    backtest_source = "cache"
             # Capture backtest settings (for closure below)
             backtest_speed = request.backtest.speed
             backtest_max_sleep = request.backtest.max_sleep
@@ -1318,9 +1274,10 @@ def create_dashboard_app(
 
         Resolution order:
         1. Local persistence_file from trial record metadata
-        2. Peer proxy (cluster mode)
-        3. OSS download (cached to output_dir/backtest_cache/)
-        4. SLS materialization (cached to output_dir/backtest_cache/, then uploaded to OSS)
+        2. Local backtest cache file
+        3. OSS download (cached locally)
+        4. Peer proxy (cluster mode — catches in-progress trials)
+        5. SLS materialization (cached locally, then uploaded to OSS)
 
         Returns the JSONL file as a streaming download.
         """
@@ -1345,7 +1302,18 @@ def create_dashboard_app(
                             event_file = alt
                             break
 
-        # 2. Try proxying to the owning peer in cluster mode
+        # 2. Try local backtest cache
+        cache_dir = state.output_dir / "backtest_cache"
+        suffix = f"-{run_id[:8]}" if run_id else ""
+        cached_path = cache_dir / f"{trial_id}{suffix}.jsonl"
+        if event_file is None and cached_path.exists():
+            event_file = cached_path
+
+        # 3. Try OSS
+        if event_file is None and download_trial_from_oss(trial_id, cached_path):
+            event_file = cached_path
+
+        # 4. Try proxying to the owning peer in cluster mode
         if event_file is None and state.peer_registry is not None:
             try:
                 owner = await state.peer_registry.get_peer_for_trial(trial_id)
@@ -1376,48 +1344,38 @@ def create_dashboard_app(
                                     )
                                 },
                             )
-                        # Peer didn't have it either — fall through to SLS
             except Exception:
                 pass  # fall through to SLS fallback
 
-        # 3. Try OSS, then SLS materialization
+        # 5. SLS materialization (last resort)
         if event_file is None:
-            output_base = state.output_dir
-            cache_dir = output_base / "backtest_cache"
-            suffix = f"-{run_id[:8]}" if run_id else ""
-            cached_path = cache_dir / f"{trial_id}{suffix}.jsonl"
-            if cached_path.exists():
-                event_file = cached_path
-            elif _try_oss_download(trial_id, cached_path):
-                event_file = cached_path
-            else:
-                try:
-                    from dojozero.data import SLSEventSource
+            try:
+                from dojozero.data import SLSEventSource
 
-                    await SLSEventSource().materialize_jsonl(
-                        trial_id,
-                        cached_path,
-                        run_id=run_id or None,
-                    )
-                    event_file = cached_path
-                    # Upload to OSS for cross-host caching
-                    _try_oss_upload(trial_id, cached_path)
-                except Exception as e:
-                    LOGGER.error(
-                        "SLS materialization failed for trial '%s': %s",
-                        trial_id,
-                        e,
-                        exc_info=True,
-                    )
-                    return JSONResponse(
-                        content={
-                            "error": (
-                                f"Event file for trial '{trial_id}' not available "
-                                f"locally and SLS fallback failed: {e}"
-                            )
-                        },
-                        status_code=424,
-                    )
+                await SLSEventSource().materialize_jsonl(
+                    trial_id,
+                    cached_path,
+                    run_id=run_id or None,
+                )
+                event_file = cached_path
+                # Upload to OSS for cross-host caching
+                upload_trial_to_oss(trial_id, cached_path)
+            except Exception as e:
+                LOGGER.error(
+                    "SLS materialization failed for trial '%s': %s",
+                    trial_id,
+                    e,
+                    exc_info=True,
+                )
+                return JSONResponse(
+                    content={
+                        "error": (
+                            f"Event file for trial '{trial_id}' not available "
+                            f"locally and SLS fallback failed: {e}"
+                        )
+                    },
+                    status_code=424,
+                )
 
         return FileResponse(
             path=event_file,

--- a/packages/dojozero/src/dojozero/dashboard_server/_server.py
+++ b/packages/dojozero/src/dojozero/dashboard_server/_server.py
@@ -167,6 +167,54 @@ def get_server_state(request: Request) -> DashboardServerState:
     return state
 
 
+def _try_oss_download(trial_id: str, cache_path: Path) -> bool:
+    """Try to download a trial's event file from OSS.
+
+    Returns True if the file was downloaded, False otherwise.
+    Gracefully handles missing deps, config, or network errors.
+    """
+    try:
+        from dojozero.utils.oss import OSSClient
+
+        client = OSSClient.from_env()
+        oss_key = f"trials/{trial_id}/events.jsonl"
+        if client.file_exists(oss_key):
+            cache_path.parent.mkdir(parents=True, exist_ok=True)
+            client.download_file(oss_key, cache_path)
+            LOGGER.info(
+                "Downloaded trial '%s' events from OSS to %s", trial_id, cache_path
+            )
+            return True
+        return False
+    except ImportError:
+        return False
+    except ValueError:
+        return False
+    except Exception as e:
+        LOGGER.debug("OSS download failed for trial '%s': %s", trial_id, e)
+        return False
+
+
+def _try_oss_upload(trial_id: str, local_path: Path) -> None:
+    """Upload a materialized event file to OSS for cross-host caching.
+
+    Fire-and-forget: logs errors but never raises.
+    """
+    try:
+        from dojozero.utils.oss import OSSClient
+
+        client = OSSClient.from_env()
+        oss_key = f"trials/{trial_id}/events.jsonl"
+        client.upload_file(local_path, oss_key)
+        LOGGER.info("Uploaded materialized events for trial '%s' to OSS", trial_id)
+    except ImportError:
+        pass
+    except ValueError:
+        pass
+    except Exception as e:
+        LOGGER.warning("OSS upload failed for trial '%s': %s", trial_id, e)
+
+
 async def _launch_backtest_trial(
     orchestrator: TrialOrchestrator,
     spec: TrialSpec,
@@ -930,8 +978,7 @@ def create_dashboard_app(
                         event_file = candidate
 
             if event_file is None:
-                # No local file — fall through to SLS materialization so that
-                # cross-server backtests work.
+                # No local file — try OSS, then SLS materialization.
                 output_base = state.output_dir
                 cache_dir = output_base / "backtest_cache"
                 # Cache naming: {trial_id}-{run_id[:8]}.jsonl
@@ -942,32 +989,41 @@ def create_dashboard_app(
                 event_file = cache_dir / f"{source_trial_id}{suffix}.jsonl"
                 materialize_result = None
                 if not event_file.exists():
-                    try:
-                        from dojozero.data import SLSEventSource
+                    # Try OSS first
+                    if _try_oss_download(source_trial_id, event_file):
+                        backtest_source = "oss"
+                    else:
+                        # Fall back to SLS materialization
+                        try:
+                            from dojozero.data import SLSEventSource
 
-                        materialize_result = await SLSEventSource().materialize_jsonl(
-                            source_trial_id,
-                            event_file,
-                            run_id=run_id or None,
-                        )
-                        backtest_source = "sls"
-                    except Exception as e:
-                        LOGGER.error(
-                            "SLS materialization failed for trial '%s': %s",
-                            source_trial_id,
-                            e,
-                            exc_info=True,
-                        )
-                        return JSONResponse(
-                            content={
-                                "error": (
-                                    f"Event file for trial '{source_trial_id}' "
-                                    f"is not available locally and SLS fallback "
-                                    f"failed."
+                            materialize_result = (
+                                await SLSEventSource().materialize_jsonl(
+                                    source_trial_id,
+                                    event_file,
+                                    run_id=run_id or None,
                                 )
-                            },
-                            status_code=424,
-                        )
+                            )
+                            backtest_source = "sls"
+                            # Upload to OSS for cross-host caching
+                            _try_oss_upload(source_trial_id, event_file)
+                        except Exception as e:
+                            LOGGER.error(
+                                "SLS materialization failed for trial '%s': %s",
+                                source_trial_id,
+                                e,
+                                exc_info=True,
+                            )
+                            return JSONResponse(
+                                content={
+                                    "error": (
+                                        f"Event file for trial '{source_trial_id}' "
+                                        f"is not available locally and SLS fallback "
+                                        f"failed."
+                                    )
+                                },
+                                status_code=424,
+                            )
                 else:
                     backtest_source = "sls"
             # Capture backtest settings (for closure below)
@@ -1262,7 +1318,9 @@ def create_dashboard_app(
 
         Resolution order:
         1. Local persistence_file from trial record metadata
-        2. SLS materialization (cached to output_dir/backtest_cache/)
+        2. Peer proxy (cluster mode)
+        3. OSS download (cached to output_dir/backtest_cache/)
+        4. SLS materialization (cached to output_dir/backtest_cache/, then uploaded to OSS)
 
         Returns the JSONL file as a streaming download.
         """
@@ -1322,13 +1380,15 @@ def create_dashboard_app(
             except Exception:
                 pass  # fall through to SLS fallback
 
-        # 3. Fallback: materialize from SLS
+        # 3. Try OSS, then SLS materialization
         if event_file is None:
             output_base = state.output_dir
             cache_dir = output_base / "backtest_cache"
             suffix = f"-{run_id[:8]}" if run_id else ""
             cached_path = cache_dir / f"{trial_id}{suffix}.jsonl"
             if cached_path.exists():
+                event_file = cached_path
+            elif _try_oss_download(trial_id, cached_path):
                 event_file = cached_path
             else:
                 try:
@@ -1340,6 +1400,8 @@ def create_dashboard_app(
                         run_id=run_id or None,
                     )
                     event_file = cached_path
+                    # Upload to OSS for cross-host caching
+                    _try_oss_upload(trial_id, cached_path)
                 except Exception as e:
                     LOGGER.error(
                         "SLS materialization failed for trial '%s': %s",

--- a/packages/dojozero/src/dojozero/dashboard_server/_server.py
+++ b/packages/dojozero/src/dojozero/dashboard_server/_server.py
@@ -120,7 +120,7 @@ class TrialSourceConfigRequest(BaseModel):
     pre_start_hours: float = 2.0
     check_interval_seconds: float = 60.0
     auto_stop_on_completion: bool = True
-    data_dir: str | None = None
+    output_dir: str | None = None
     max_daily_games: int = 0
 
 
@@ -146,7 +146,9 @@ class DashboardServerState:
     schedule_manager: Any | None = None  # ScheduleManager, lazy import
     trace_backend: str | None = None
     oss_backup: bool = False
-    data_dir: Path | None = None  # Base directory for trial data files
+    output_dir: Path = field(
+        default_factory=lambda: Path("outputs")
+    )  # Base directory for trial output/event files
     imported_modules: set[str] = field(default_factory=set)
     import_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
     server_id: str | None = None
@@ -317,7 +319,7 @@ def _register_initial_sources(
             pre_start_hours=config_data.get("pre_start_hours", 2.0),
             check_interval_seconds=config_data.get("check_interval_seconds", 60.0),
             auto_stop_on_completion=config_data.get("auto_stop_on_completion", True),
-            data_dir=config_data.get("data_dir"),
+            output_dir=config_data.get("output_dir"),
             sync_interval_seconds=config_data.get("sync_interval_seconds", 300.0),
             max_daily_games=config_data.get("max_daily_games", 0),
         )
@@ -358,7 +360,7 @@ def create_dashboard_app(
     auto_resume: bool = True,
     stale_threshold_hours: float = 24.0,
     enable_gateway: bool = True,
-    data_dir: str | Path | None = None,
+    output_dir: str | Path = "outputs",
     authenticator: "AgentAuthenticator | None" = None,
     no_scheduler: bool = False,
     cluster_config: ClusterConfig | None = None,
@@ -377,8 +379,7 @@ def create_dashboard_app(
         auto_resume: Automatically resume interrupted trials on startup (default True)
         stale_threshold_hours: Skip resuming trials older than this many hours (default 24)
         enable_gateway: Enable HTTP gateway routing for external agents (default True)
-        data_dir: Base directory for trial data files (persistence_file will be generated
-            under this directory). If None, trials must provide their own persistence_file.
+        output_dir: Base directory for trial output/event files (default: "outputs").
         authenticator: AgentAuthenticator for validating agent API keys. If None and
             agent_keys.yaml exists, uses LocalAgentAuthenticator. Otherwise NoOpAuthenticator.
         no_scheduler: Disable the ScheduleManager entirely (no auto-scheduling, no
@@ -443,6 +444,7 @@ def create_dashboard_app(
                 store=scheduler_store,
                 peer_registry=peer_registry_instance,
                 server_id=server_id,
+                output_dir=Path(output_dir).resolve(),
             )
 
         # Create schedule manager — gated on leadership in cluster mode
@@ -468,7 +470,7 @@ def create_dashboard_app(
             schedule_manager=schedule_manager,
             trace_backend=trace_backend,
             oss_backup=oss_backup,
-            data_dir=Path(data_dir).resolve() if data_dir else None,
+            output_dir=Path(output_dir).resolve(),
             server_id=server_id,
             leader_elector=leader_elector_instance,
             peer_registry=peer_registry_instance,
@@ -866,25 +868,26 @@ def create_dashboard_app(
         # Prepare config with server-generated persistence_file for security
         # User-provided persistence_file paths are NOT trusted (path traversal risk)
         builder_config = dict(scenario.config or scenario_config)
-        if state.data_dir:
-            # Generate safe persistence_file path based on trial_id
-            from datetime import date
+        output_base = state.output_dir
 
-            date_str = date.today().isoformat()
-            safe_persistence_file = (
-                state.data_dir / scenario.name / date_str / f"{trial_id}.jsonl"
-            )
-            safe_persistence_file.parent.mkdir(parents=True, exist_ok=True)
+        # Generate safe persistence_file path based on trial_id
+        from datetime import date
 
-            # Inject into hub config (override any user-provided value)
-            if "hub" not in builder_config:
-                builder_config["hub"] = {}
-            builder_config["hub"]["persistence_file"] = str(safe_persistence_file)
-            LOGGER.debug(
-                "Generated persistence_file for trial %s: %s",
-                trial_id,
-                safe_persistence_file,
-            )
+        date_str = date.today().isoformat()
+        safe_persistence_file = (
+            output_base / scenario.name / date_str / f"{trial_id}.jsonl"
+        )
+        safe_persistence_file.parent.mkdir(parents=True, exist_ok=True)
+
+        # Inject into hub config (override any user-provided value)
+        if "hub" not in builder_config:
+            builder_config["hub"] = {}
+        builder_config["hub"]["persistence_file"] = str(safe_persistence_file)
+        LOGGER.debug(
+            "Generated persistence_file for trial %s: %s",
+            trial_id,
+            safe_persistence_file,
+        )
 
         # Build the trial spec - uses build_async which handles both sync and async builders
         try:
@@ -927,32 +930,10 @@ def create_dashboard_app(
                         event_file = candidate
 
             if event_file is None:
-                # No local file — only fall through to SLS if the record
-                # is missing (ran elsewhere) or its file is gone.  When
-                # the record itself is absent we still attempt SLS so that
+                # No local file — fall through to SLS materialization so that
                 # cross-server backtests work.
-                if state.data_dir is None:
-                    if source_record is None:
-                        return JSONResponse(
-                            content={
-                                "error": (
-                                    f"Trial '{source_trial_id}' not found on "
-                                    f"this server and data_dir is not "
-                                    f"configured for SLS fallback."
-                                )
-                            },
-                            status_code=404,
-                        )
-                    return JSONResponse(
-                        content={
-                            "error": (
-                                "Server data_dir is not configured; cannot "
-                                "cache SLS-sourced backtest events."
-                            )
-                        },
-                        status_code=500,
-                    )
-                cache_dir = Path(state.data_dir) / "backtest_cache"
+                output_base = state.output_dir
+                cache_dir = output_base / "backtest_cache"
                 # Cache naming: {trial_id}-{run_id[:8]}.jsonl
                 # 8-char prefix of the 16-hex span_id is sufficient to
                 # avoid collisions while keeping filenames readable.
@@ -1281,7 +1262,7 @@ def create_dashboard_app(
 
         Resolution order:
         1. Local persistence_file from trial record metadata
-        2. SLS materialization (cached to data_dir/backtest_cache/)
+        2. SLS materialization (cached to output_dir/backtest_cache/)
 
         Returns the JSONL file as a streaming download.
         """
@@ -1299,9 +1280,9 @@ def create_dashboard_app(
                     if candidate.exists():
                         event_file = candidate
                         break
-                    # Try resolving relative to data_dir if configured
-                    if state.data_dir and not candidate.is_absolute():
-                        alt = Path(state.data_dir) / candidate
+                    # Try resolving relative to output_dir
+                    if not candidate.is_absolute():
+                        alt = Path(state.output_dir) / candidate
                         if alt.exists():
                             event_file = alt
                             break
@@ -1343,17 +1324,8 @@ def create_dashboard_app(
 
         # 3. Fallback: materialize from SLS
         if event_file is None:
-            if state.data_dir is None:
-                return JSONResponse(
-                    content={
-                        "error": (
-                            f"Event file for trial '{trial_id}' not found locally "
-                            f"and data_dir is not configured for SLS fallback."
-                        )
-                    },
-                    status_code=404,
-                )
-            cache_dir = Path(state.data_dir) / "backtest_cache"
+            output_base = state.output_dir
+            cache_dir = output_base / "backtest_cache"
             suffix = f"-{run_id[:8]}" if run_id else ""
             cached_path = cache_dir / f"{trial_id}{suffix}.jsonl"
             if cached_path.exists():
@@ -1633,7 +1605,7 @@ def create_dashboard_app(
                 pre_start_hours=request.config.pre_start_hours,
                 check_interval_seconds=request.config.check_interval_seconds,
                 auto_stop_on_completion=request.config.auto_stop_on_completion,
-                data_dir=request.config.data_dir,
+                output_dir=request.config.output_dir,
                 max_daily_games=request.config.max_daily_games,
             )
 
@@ -2004,7 +1976,7 @@ async def run_dashboard_server(
     auto_resume: bool = True,
     stale_threshold_hours: float = 24.0,
     enable_gateway: bool = True,
-    data_dir: str | Path | None = None,
+    output_dir: str | Path = "outputs",
     authenticator: "AgentAuthenticator | None" = None,
     no_scheduler: bool = False,
     cluster_config: ClusterConfig | None = None,
@@ -2025,8 +1997,7 @@ async def run_dashboard_server(
         auto_resume: Automatically resume interrupted trials on startup (default True)
         stale_threshold_hours: Skip resuming trials older than this many hours (default 24)
         enable_gateway: Enable HTTP gateway routing for external agents
-        data_dir: Base directory for trial data files (persistence_file will be generated
-            under this directory). If None, trials must provide their own persistence_file.
+        output_dir: Base directory for trial output/event files (default: "outputs").
         authenticator: AgentAuthenticator for validating agent API keys
         no_scheduler: Disable the ScheduleManager entirely
     """
@@ -2044,7 +2015,7 @@ async def run_dashboard_server(
         auto_resume=auto_resume,
         stale_threshold_hours=stale_threshold_hours,
         enable_gateway=enable_gateway,
-        data_dir=data_dir,
+        output_dir=output_dir,
         authenticator=authenticator,
         no_scheduler=no_scheduler,
         cluster_config=cluster_config,

--- a/packages/dojozero/src/dojozero/dashboard_server/_trial_manager.py
+++ b/packages/dojozero/src/dojozero/dashboard_server/_trial_manager.py
@@ -1053,6 +1053,10 @@ class TrialManager:
             except Exception as e:
                 self._logger.error("Error stopping trial %s: %s", trial_id, e)
 
+            # Upload to OSS after stopping (before returning)
+            if self._oss_backup and final_phase == QueuedTrialPhase.COMPLETED:
+                self._upload_to_oss(trial_id, queued.spec)
+
             return True
 
         return False
@@ -1212,6 +1216,9 @@ class TrialManager:
                     queued.phase = QueuedTrialPhase.COMPLETED
             except TrialNotFoundError:
                 queued.phase = QueuedTrialPhase.COMPLETED
+
+            if self._oss_backup and queued.phase == QueuedTrialPhase.COMPLETED:
+                self._upload_to_oss(trial_id, queued.spec)
 
             self._logger.info(
                 "Resumed trial '%s' finished with phase: %s",

--- a/packages/dojozero/src/dojozero/dashboard_server/_trial_manager.py
+++ b/packages/dojozero/src/dojozero/dashboard_server/_trial_manager.py
@@ -1453,8 +1453,31 @@ class TrialManager:
             upload_trial_to_oss(trial_id, persistence_file)
 
 
+# ---------------------------------------------------------------------------
+# Shared OSS helpers (singleton client, upload/download for trial event files)
+# ---------------------------------------------------------------------------
+
 # Lazy import for OSS to avoid import errors if oss2 not installed
 _oss_client = None
+
+
+def _oss_trial_key(trial_id: str) -> str:
+    """OSS object key for a trial's event file."""
+    return f"trials/{trial_id}/events.jsonl"
+
+
+def _get_oss_client():  # noqa: ANN202
+    """Return the singleton OSSClient, creating it on first call.
+
+    Raises ImportError if oss2 is not installed, ValueError if env is
+    not configured.
+    """
+    global _oss_client
+    if _oss_client is None:
+        from dojozero.utils.oss import OSSClient
+
+        _oss_client = OSSClient.from_env()
+    return _oss_client
 
 
 def upload_trial_to_oss(trial_id: str, persistence_file: Path | None) -> bool:
@@ -1467,21 +1490,14 @@ def upload_trial_to_oss(trial_id: str, persistence_file: Path | None) -> bool:
     Returns:
         True if upload succeeded, False otherwise
     """
-    global _oss_client
-
     if not persistence_file or not persistence_file.exists():
         LOGGER.warning("No persistence file to upload for trial %s", trial_id)
         return False
 
     try:
-        from dojozero.utils.oss import OSSClient
-
-        if _oss_client is None:
-            _oss_client = OSSClient.from_env()
-
-        # Upload with key: trials/{trial_id}/events.jsonl
-        oss_key = f"trials/{trial_id}/events.jsonl"
-        full_key = _oss_client.upload_file(persistence_file, oss_key)
+        client = _get_oss_client()
+        oss_key = _oss_trial_key(trial_id)
+        full_key = client.upload_file(persistence_file, oss_key)
         LOGGER.info("Uploaded trial data to OSS: %s", full_key)
         return True
 
@@ -1499,9 +1515,35 @@ def upload_trial_to_oss(trial_id: str, persistence_file: Path | None) -> bool:
         return False
 
 
+def download_trial_from_oss(trial_id: str, cache_path: Path) -> bool:
+    """Download a trial's event file from OSS to a local cache path.
+
+    Returns True if downloaded, False otherwise.  Never raises.
+    """
+    try:
+        client = _get_oss_client()
+        oss_key = _oss_trial_key(trial_id)
+        if client.file_exists(oss_key):
+            cache_path.parent.mkdir(parents=True, exist_ok=True)
+            client.download_file(oss_key, cache_path)
+            LOGGER.info(
+                "Downloaded trial '%s' events from OSS to %s", trial_id, cache_path
+            )
+            return True
+        return False
+    except ImportError:
+        return False
+    except ValueError:
+        return False
+    except Exception as e:
+        LOGGER.debug("OSS download failed for trial '%s': %s", trial_id, e)
+        return False
+
+
 __all__ = [
     "QueuedTrial",
     "QueuedTrialPhase",
     "TrialManager",
+    "download_trial_from_oss",
     "upload_trial_to_oss",
 ]

--- a/packages/dojozero/src/dojozero/dashboard_server/_trial_manager.py
+++ b/packages/dojozero/src/dojozero/dashboard_server/_trial_manager.py
@@ -1454,8 +1454,48 @@ class TrialManager:
 
 
 # ---------------------------------------------------------------------------
-# Shared OSS helpers (singleton client, upload/download for trial event files)
+# Shared trial-cache and OSS helpers
 # ---------------------------------------------------------------------------
+
+
+def trials_cache_path(
+    output_dir: Path, trial_id: str, run_id: str | None = None
+) -> Path:
+    """Canonical local cache path for a trial's event file.
+
+    Returns ``output_dir / "trials" / "{trial_id}[-{run_id[:8]}].jsonl"``.
+    """
+    suffix = f"-{run_id[:8]}" if run_id else ""
+    return output_dir / "trials" / f"{trial_id}{suffix}.jsonl"
+
+
+def ensure_trial_symlink(
+    output_dir: Path, trial_id: str, persistence_file: Path
+) -> None:
+    """Create symlink ``outputs/trials/{trial_id}.jsonl`` → *persistence_file*.
+
+    Uses a relative path so the tree is relocatable.  No-op if the symlink
+    already exists and points to the same target, or if a real file already
+    occupies the path (e.g. from an OSS download).  Best-effort — logs and
+    swallows errors.
+    """
+    import os
+
+    link_path = trials_cache_path(output_dir, trial_id)
+    link_path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        target = os.path.relpath(persistence_file, link_path.parent)
+        if link_path.is_symlink():
+            if os.readlink(str(link_path)) == target:
+                return
+            link_path.unlink()
+        elif link_path.exists():
+            return  # real file (e.g. from OSS download) — don't clobber
+        os.symlink(target, link_path)
+        LOGGER.debug("Created trial symlink %s → %s", link_path, target)
+    except OSError:
+        LOGGER.debug("Could not create trial symlink %s", link_path, exc_info=True)
+
 
 # Lazy import for OSS to avoid import errors if oss2 not installed
 _oss_client = None
@@ -1545,5 +1585,7 @@ __all__ = [
     "QueuedTrialPhase",
     "TrialManager",
     "download_trial_from_oss",
+    "ensure_trial_symlink",
+    "trials_cache_path",
     "upload_trial_to_oss",
 ]

--- a/packages/dojozero/src/dojozero/dashboard_server/_types.py
+++ b/packages/dojozero/src/dojozero/dashboard_server/_types.py
@@ -154,7 +154,7 @@ class TrialSourceConfigDict(TypedDict, total=False):
     pre_start_hours: float
     check_interval_seconds: float
     auto_stop_on_completion: bool
-    data_dir: str | None
+    output_dir: str | None
     sync_interval_seconds: float
     max_daily_games: int
 

--- a/packages/dojozero/src/dojozero/data/_config.py
+++ b/packages/dojozero/src/dojozero/data/_config.py
@@ -21,7 +21,7 @@ class HubConfig(BaseModel):
 
     Note: Persistence is always enabled. The persistence_file is optional here
     because for auto-scheduled trials, it gets populated dynamically by the
-    scheduler based on data_dir. Trial builders should validate that it's set
+    scheduler based on output_dir. Trial builders should validate that it's set
     before building the trial spec.
     """
 

--- a/packages/dojozero/src/dojozero/nba/_trial.py
+++ b/packages/dojozero/src/dojozero/nba/_trial.py
@@ -150,7 +150,7 @@ async def _build_trial_spec(
     if not params.hub.persistence_file:
         raise ValueError(
             "hub.persistence_file is required. For auto-scheduled trials, ensure "
-            "data_dir is set in the trial source config so the scheduler can "
+            "output_dir is set in the trial source config so the scheduler can "
             "populate this field."
         )
     persistence_file = params.hub.persistence_file.replace(

--- a/packages/dojozero/src/dojozero/ncaa/_trial.py
+++ b/packages/dojozero/src/dojozero/ncaa/_trial.py
@@ -136,7 +136,7 @@ async def _build_trial_spec(
     if not params.hub.persistence_file:
         raise ValueError(
             "hub.persistence_file is required. For auto-scheduled trials, ensure "
-            "data_dir is set in the trial source config so the scheduler can "
+            "output_dir is set in the trial source config so the scheduler can "
             "populate this field."
         )
     persistence_file = params.hub.persistence_file

--- a/packages/dojozero/src/dojozero/nfl/_trial.py
+++ b/packages/dojozero/src/dojozero/nfl/_trial.py
@@ -155,7 +155,7 @@ async def _build_trial_spec(
     if not params.hub.persistence_file:
         raise ValueError(
             "hub.persistence_file is required. For auto-scheduled trials, ensure "
-            "data_dir is set in the trial source config so the scheduler can "
+            "output_dir is set in the trial source config so the scheduler can "
             "populate this field."
         )
     persistence_file = params.hub.persistence_file.replace(

--- a/packages/dojozero/src/dojozero/utils/oss.py
+++ b/packages/dojozero/src/dojozero/utils/oss.py
@@ -79,6 +79,20 @@ def _credentials_provider_type() -> type:
     return AlibabaCloudCredentialsProvider
 
 
+def _extract_region(endpoint: str) -> str:
+    """Extract region from OSS endpoint.
+
+    e.g., "oss-cn-wulanchabu.aliyuncs.com" → "cn-wulanchabu"
+         "oss-cn-hangzhou-internal.aliyuncs.com" → "cn-hangzhou"
+    """
+    host = endpoint.split("//")[-1].split(":")[0]  # strip scheme and port
+    # Remove "oss-" prefix and ".aliyuncs.com" suffix
+    region = host.removeprefix("oss-").split(".")[0]
+    # Strip "-internal" suffix if present
+    region = region.removesuffix("-internal")
+    return region
+
+
 class OSSClient:
     """Client for interacting with Alibaba Cloud OSS."""
 
@@ -92,11 +106,16 @@ class OSSClient:
         access_key_id: str | None = None,
         access_key_secret: str | None = None,
         security_token: str | None = None,
+        region: str | None = None,
     ):
         oss = _require_oss2()
         self.bucket_name = bucket_name
         self.endpoint = endpoint
         self.prefix = prefix.rstrip("/") + "/" if prefix else ""
+
+        # Extract region from endpoint (e.g., "oss-cn-wulanchabu.aliyuncs.com" → "cn-wulanchabu")
+        if region is None:
+            region = _extract_region(endpoint)
 
         if credentials_provider is not None:
             self._auth = oss.ProviderAuthV4(credentials_provider)
@@ -112,7 +131,7 @@ class OSSClient:
                 "Either credentials_provider or (access_key_id + access_key_secret) must be provided"
             )
 
-        self._bucket = oss.Bucket(self._auth, endpoint, bucket_name)
+        self._bucket = oss.Bucket(self._auth, endpoint, bucket_name, region=region)
 
     @classmethod
     def from_env(

--- a/packages/dojozero/tests/test_backtest_cache_naming.py
+++ b/packages/dojozero/tests/test_backtest_cache_naming.py
@@ -1,93 +1,144 @@
-"""Tests for SLS backtest cache filename scheme.
+"""Tests for trial cache filename scheme and symlink helpers.
 
-The server and CLI must use the same naming convention:
+The server and CLI use a canonical ``outputs/trials/`` directory:
   {trial_id}.jsonl              (no run_id)
   {trial_id}-{run_id[:8]}.jsonl (with run_id)
 
 8-char prefix of the 16-hex span_id keeps filenames readable while
-avoiding collisions.  _select_run accepts both full and prefix matches
-so users can pass either form.
+avoiding collisions.
 """
 
+import os
 from pathlib import Path
 
+from dojozero.dashboard_server._trial_manager import (
+    ensure_trial_symlink,
+    trials_cache_path,
+)
 
-def _cache_filename(trial_id: str, run_id: str | None) -> str:
-    """Reproduce the cache naming logic from _server.py and cli.py."""
-    suffix = f"-{run_id[:8]}" if run_id else ""
-    return f"{trial_id}{suffix}.jsonl"
 
+class TestTrialsCachePath:
+    """Verify trials_cache_path produces expected paths."""
 
-class TestCacheNaming:
-    """Verify cache filename construction matches CLI convention."""
+    def test_no_run_id(self, tmp_path: Path) -> None:
+        result = trials_cache_path(tmp_path, "abc123")
+        assert result == tmp_path / "trials" / "abc123.jsonl"
 
-    def test_no_run_id(self) -> None:
-        assert _cache_filename("abc123", None) == "abc123.jsonl"
+    def test_empty_run_id(self, tmp_path: Path) -> None:
+        result = trials_cache_path(tmp_path, "abc123", "")
+        assert result == tmp_path / "trials" / "abc123.jsonl"
 
-    def test_empty_run_id(self) -> None:
-        assert _cache_filename("abc123", "") == "abc123.jsonl"
+    def test_with_run_id(self, tmp_path: Path) -> None:
+        result = trials_cache_path(tmp_path, "trial-1", "abcdef1234567890")
+        assert result == tmp_path / "trials" / "trial-1-abcdef12.jsonl"
 
-    def test_run_id_truncated_to_8_chars(self) -> None:
-        run_id = "abcdef1234567890"
-        result = _cache_filename("trial-1", run_id)
-        assert result == "trial-1-abcdef12.jsonl"
+    def test_short_run_id(self, tmp_path: Path) -> None:
+        result = trials_cache_path(tmp_path, "trial-1", "abc")
+        assert result == tmp_path / "trials" / "trial-1-abc.jsonl"
 
-    def test_short_run_id_not_padded(self) -> None:
-        result = _cache_filename("trial-1", "abc")
-        assert result == "trial-1-abc.jsonl"
-
-    def test_different_run_ids_produce_different_files(self) -> None:
-        f1 = _cache_filename("trial-1", "run_aaa_1234")
-        f2 = _cache_filename("trial-1", "run_bbb_5678")
-        assert f1 != f2
-
-    def test_same_run_id_produces_same_file(self) -> None:
-        f1 = _cache_filename("trial-1", "run_aaa_1234")
-        f2 = _cache_filename("trial-1", "run_aaa_1234")
-        assert f1 == f2
+    def test_different_run_ids(self, tmp_path: Path) -> None:
+        p1 = trials_cache_path(tmp_path, "trial-1", "run_aaa_1234")
+        p2 = trials_cache_path(tmp_path, "trial-1", "run_bbb_5678")
+        assert p1 != p2
 
 
 class TestCacheHitMiss:
-    """Verify cache reuse behavior (file exists → skip fetch)."""
+    """Verify cache reuse behavior (file exists -> skip fetch)."""
 
     def test_cache_hit_skips_materialization(self, tmp_path: Path) -> None:
         """When cache file exists, no SLS fetch should be needed."""
-        trial_id = "trial-xyz"
-        run_id = "run12345678abcdef"
-        cache_dir = tmp_path / "backtest_cache"
-        cache_dir.mkdir()
-
-        suffix = f"-{run_id[:8]}" if run_id else ""
-        event_file = cache_dir / f"{trial_id}{suffix}.jsonl"
-        event_file.write_text('{"event": "test"}\n')
-
-        # File exists → cache hit
-        assert event_file.exists()
+        p = trials_cache_path(tmp_path, "trial-xyz", "run12345678abcdef")
+        p.parent.mkdir(parents=True)
+        p.write_text('{"event": "test"}\n')
+        assert p.exists()
 
     def test_cache_miss_for_different_run_id(self, tmp_path: Path) -> None:
         """A cached file for run_A should NOT satisfy a request for run_B."""
-        trial_id = "trial-xyz"
-        cache_dir = tmp_path / "backtest_cache"
-        cache_dir.mkdir()
+        p_a = trials_cache_path(tmp_path, "trial-xyz", "run_aaaa_xxx")
+        p_a.parent.mkdir(parents=True)
+        p_a.write_text('{"event": "test"}\n')
 
-        # Cache file for run_A
-        file_a = cache_dir / f"{trial_id}-run_aaaa.jsonl"
-        file_a.write_text('{"event": "test"}\n')
-
-        # Request for run_B → different filename → miss
-        file_b = cache_dir / f"{trial_id}-run_bbbb.jsonl"
-        assert not file_b.exists()
+        p_b = trials_cache_path(tmp_path, "trial-xyz", "run_bbbb_xxx")
+        assert not p_b.exists()
 
     def test_no_run_id_does_not_match_run_id_file(self, tmp_path: Path) -> None:
         """A request with no run_id should not reuse a run_id-specific cache."""
-        trial_id = "trial-xyz"
-        cache_dir = tmp_path / "backtest_cache"
-        cache_dir.mkdir()
-
-        # Cache file for a specific run
-        specific = cache_dir / f"{trial_id}-run_aaaa.jsonl"
+        specific = trials_cache_path(tmp_path, "trial-xyz", "run_aaaa_xxx")
+        specific.parent.mkdir(parents=True)
         specific.write_text('{"event": "test"}\n')
 
-        # No-run_id request → plain filename → miss
-        plain = cache_dir / f"{trial_id}.jsonl"
+        plain = trials_cache_path(tmp_path, "trial-xyz")
         assert not plain.exists()
+
+
+class TestEnsureTrialSymlink:
+    """Tests for ensure_trial_symlink helper."""
+
+    def test_creates_symlink(self, tmp_path: Path) -> None:
+        persistence = tmp_path / "2026-04-21" / "sched-nba-123.jsonl"
+        persistence.parent.mkdir(parents=True)
+        persistence.write_text('{"event": "data"}\n')
+
+        ensure_trial_symlink(tmp_path, "nba-game-123-abcd1234", persistence)
+
+        link = tmp_path / "trials" / "nba-game-123-abcd1234.jsonl"
+        assert link.is_symlink()
+        assert link.exists()  # follows symlink
+        assert link.read_text() == '{"event": "data"}\n'
+
+    def test_uses_relative_path(self, tmp_path: Path) -> None:
+        persistence = tmp_path / "2026-04-21" / "sched-nba-123.jsonl"
+        persistence.parent.mkdir(parents=True)
+        persistence.write_text("data")
+
+        ensure_trial_symlink(tmp_path, "trial-1", persistence)
+
+        link = tmp_path / "trials" / "trial-1.jsonl"
+        target = os.readlink(str(link))
+        assert not os.path.isabs(target)
+        assert target == "../2026-04-21/sched-nba-123.jsonl"
+
+    def test_idempotent(self, tmp_path: Path) -> None:
+        persistence = tmp_path / "data" / "file.jsonl"
+        persistence.parent.mkdir(parents=True)
+        persistence.write_text("data")
+
+        ensure_trial_symlink(tmp_path, "trial-1", persistence)
+        ensure_trial_symlink(tmp_path, "trial-1", persistence)
+
+        link = tmp_path / "trials" / "trial-1.jsonl"
+        assert link.is_symlink()
+        assert link.exists()
+
+    def test_does_not_clobber_real_file(self, tmp_path: Path) -> None:
+        """If a real file exists (e.g. from OSS download), don't replace it."""
+        trials_dir = tmp_path / "trials"
+        trials_dir.mkdir(parents=True)
+        real_file = trials_dir / "trial-1.jsonl"
+        real_file.write_text("oss data")
+
+        persistence = tmp_path / "data" / "file.jsonl"
+        persistence.parent.mkdir(parents=True)
+        persistence.write_text("live data")
+
+        ensure_trial_symlink(tmp_path, "trial-1", persistence)
+
+        assert not real_file.is_symlink()
+        assert real_file.read_text() == "oss data"
+
+    def test_replaces_stale_symlink(self, tmp_path: Path) -> None:
+        """If symlink points to old target, update it."""
+        old_persistence = tmp_path / "old" / "file.jsonl"
+        old_persistence.parent.mkdir(parents=True)
+        old_persistence.write_text("old")
+
+        ensure_trial_symlink(tmp_path, "trial-1", old_persistence)
+
+        new_persistence = tmp_path / "new" / "file.jsonl"
+        new_persistence.parent.mkdir(parents=True)
+        new_persistence.write_text("new")
+
+        ensure_trial_symlink(tmp_path, "trial-1", new_persistence)
+
+        link = tmp_path / "trials" / "trial-1.jsonl"
+        assert os.readlink(str(link)) == "../new/file.jsonl"

--- a/packages/dojozero/tests/test_oss.py
+++ b/packages/dojozero/tests/test_oss.py
@@ -1,11 +1,12 @@
 """Unit tests for OSS utilities."""
 
 from contextlib import contextmanager
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-from dojozero.utils.oss import OSSClient, upload_directory, upload_file
+from dojozero.utils.oss import OSSClient, _extract_region, upload_directory, upload_file
 
 
 def _patch_require_oss2():
@@ -487,3 +488,143 @@ class TestConvenienceFunctions:
 
         assert len(result) == 1
         mock_bucket.put_object_from_file.assert_called_once()
+
+
+class TestExtractRegion:
+    """Tests for _extract_region helper."""
+
+    def test_standard_endpoint(self):
+        assert _extract_region("oss-cn-hangzhou.aliyuncs.com") == "cn-hangzhou"
+
+    def test_internal_endpoint(self):
+        assert _extract_region("oss-cn-hangzhou-internal.aliyuncs.com") == "cn-hangzhou"
+
+    def test_with_scheme(self):
+        assert (
+            _extract_region("https://oss-cn-wulanchabu.aliyuncs.com") == "cn-wulanchabu"
+        )
+
+    def test_with_port(self):
+        assert _extract_region("oss-cn-beijing.aliyuncs.com:443") == "cn-beijing"
+
+    def test_internal_with_scheme(self):
+        assert (
+            _extract_region("https://oss-cn-wulanchabu-internal.aliyuncs.com")
+            == "cn-wulanchabu"
+        )
+
+
+class TestTryOssDownload:
+    """Tests for _try_oss_download server helper."""
+
+    def test_returns_true_on_success(self, tmp_path: Path):
+        mock_client = MagicMock()
+        mock_client.file_exists.return_value = True
+
+        with patch(
+            "dojozero.utils.oss.OSSClient.from_env",
+            return_value=mock_client,
+        ):
+            from dojozero.dashboard_server._server import _try_oss_download
+
+            cache_path = tmp_path / "cache" / "events.jsonl"
+            result = _try_oss_download("trial-123", cache_path)
+
+        assert result is True
+        mock_client.file_exists.assert_called_once_with("trials/trial-123/events.jsonl")
+        mock_client.download_file.assert_called_once_with(
+            "trials/trial-123/events.jsonl", cache_path
+        )
+
+    def test_returns_false_when_not_found(self, tmp_path: Path):
+        mock_client = MagicMock()
+        mock_client.file_exists.return_value = False
+
+        with patch(
+            "dojozero.utils.oss.OSSClient.from_env",
+            return_value=mock_client,
+        ):
+            from dojozero.dashboard_server._server import _try_oss_download
+
+            result = _try_oss_download("trial-123", tmp_path / "events.jsonl")
+
+        assert result is False
+        mock_client.download_file.assert_not_called()
+
+    def test_returns_false_on_import_error(self, tmp_path: Path):
+        with patch(
+            "dojozero.utils.oss.OSSClient.from_env",
+            side_effect=ImportError("no oss2"),
+        ):
+            from dojozero.dashboard_server._server import _try_oss_download
+
+            result = _try_oss_download("trial-123", tmp_path / "events.jsonl")
+
+        assert result is False
+
+    def test_returns_false_on_value_error(self, tmp_path: Path):
+        with patch(
+            "dojozero.utils.oss.OSSClient.from_env",
+            side_effect=ValueError("missing env"),
+        ):
+            from dojozero.dashboard_server._server import _try_oss_download
+
+            result = _try_oss_download("trial-123", tmp_path / "events.jsonl")
+
+        assert result is False
+
+    def test_creates_parent_dirs(self, tmp_path: Path):
+        mock_client = MagicMock()
+        mock_client.file_exists.return_value = True
+
+        with patch(
+            "dojozero.utils.oss.OSSClient.from_env",
+            return_value=mock_client,
+        ):
+            from dojozero.dashboard_server._server import _try_oss_download
+
+            cache_path = tmp_path / "deep" / "nested" / "events.jsonl"
+            _try_oss_download("trial-123", cache_path)
+
+        assert cache_path.parent.exists()
+
+
+class TestTryOssUpload:
+    """Tests for _try_oss_upload server helper."""
+
+    def test_uploads_file(self, tmp_path: Path):
+        local_file = tmp_path / "events.jsonl"
+        local_file.write_text('{"event": "test"}\n')
+
+        mock_client = MagicMock()
+
+        with patch(
+            "dojozero.utils.oss.OSSClient.from_env",
+            return_value=mock_client,
+        ):
+            from dojozero.dashboard_server._server import _try_oss_upload
+
+            _try_oss_upload("trial-123", local_file)
+
+        mock_client.upload_file.assert_called_once_with(
+            local_file, "trials/trial-123/events.jsonl"
+        )
+
+    def test_silently_handles_import_error(self, tmp_path: Path):
+        with patch(
+            "dojozero.utils.oss.OSSClient.from_env",
+            side_effect=ImportError("no oss2"),
+        ):
+            from dojozero.dashboard_server._server import _try_oss_upload
+
+            # Should not raise
+            _try_oss_upload("trial-123", tmp_path / "events.jsonl")
+
+    def test_silently_handles_value_error(self, tmp_path: Path):
+        with patch(
+            "dojozero.utils.oss.OSSClient.from_env",
+            side_effect=ValueError("missing env"),
+        ):
+            from dojozero.dashboard_server._server import _try_oss_upload
+
+            _try_oss_upload("trial-123", tmp_path / "events.jsonl")

--- a/packages/dojozero/tests/test_oss.py
+++ b/packages/dojozero/tests/test_oss.py
@@ -514,10 +514,21 @@ class TestExtractRegion:
         )
 
 
-class TestTryOssDownload:
-    """Tests for _try_oss_download server helper."""
+@pytest.fixture(autouse=False)
+def _reset_oss_singleton():
+    """Reset the singleton OSS client between tests."""
+    import dojozero.dashboard_server._trial_manager as tm
 
-    def test_returns_true_on_success(self, tmp_path: Path):
+    old = tm._oss_client
+    tm._oss_client = None
+    yield
+    tm._oss_client = old
+
+
+class TestDownloadTrialFromOss:
+    """Tests for download_trial_from_oss helper."""
+
+    def test_returns_true_on_success(self, tmp_path: Path, _reset_oss_singleton):
         mock_client = MagicMock()
         mock_client.file_exists.return_value = True
 
@@ -525,10 +536,10 @@ class TestTryOssDownload:
             "dojozero.utils.oss.OSSClient.from_env",
             return_value=mock_client,
         ):
-            from dojozero.dashboard_server._server import _try_oss_download
+            from dojozero.dashboard_server._trial_manager import download_trial_from_oss
 
             cache_path = tmp_path / "cache" / "events.jsonl"
-            result = _try_oss_download("trial-123", cache_path)
+            result = download_trial_from_oss("trial-123", cache_path)
 
         assert result is True
         mock_client.file_exists.assert_called_once_with("trials/trial-123/events.jsonl")
@@ -536,7 +547,7 @@ class TestTryOssDownload:
             "trials/trial-123/events.jsonl", cache_path
         )
 
-    def test_returns_false_when_not_found(self, tmp_path: Path):
+    def test_returns_false_when_not_found(self, tmp_path: Path, _reset_oss_singleton):
         mock_client = MagicMock()
         mock_client.file_exists.return_value = False
 
@@ -544,36 +555,36 @@ class TestTryOssDownload:
             "dojozero.utils.oss.OSSClient.from_env",
             return_value=mock_client,
         ):
-            from dojozero.dashboard_server._server import _try_oss_download
+            from dojozero.dashboard_server._trial_manager import download_trial_from_oss
 
-            result = _try_oss_download("trial-123", tmp_path / "events.jsonl")
+            result = download_trial_from_oss("trial-123", tmp_path / "events.jsonl")
 
         assert result is False
         mock_client.download_file.assert_not_called()
 
-    def test_returns_false_on_import_error(self, tmp_path: Path):
+    def test_returns_false_on_import_error(self, tmp_path: Path, _reset_oss_singleton):
         with patch(
             "dojozero.utils.oss.OSSClient.from_env",
             side_effect=ImportError("no oss2"),
         ):
-            from dojozero.dashboard_server._server import _try_oss_download
+            from dojozero.dashboard_server._trial_manager import download_trial_from_oss
 
-            result = _try_oss_download("trial-123", tmp_path / "events.jsonl")
+            result = download_trial_from_oss("trial-123", tmp_path / "events.jsonl")
 
         assert result is False
 
-    def test_returns_false_on_value_error(self, tmp_path: Path):
+    def test_returns_false_on_value_error(self, tmp_path: Path, _reset_oss_singleton):
         with patch(
             "dojozero.utils.oss.OSSClient.from_env",
             side_effect=ValueError("missing env"),
         ):
-            from dojozero.dashboard_server._server import _try_oss_download
+            from dojozero.dashboard_server._trial_manager import download_trial_from_oss
 
-            result = _try_oss_download("trial-123", tmp_path / "events.jsonl")
+            result = download_trial_from_oss("trial-123", tmp_path / "events.jsonl")
 
         assert result is False
 
-    def test_creates_parent_dirs(self, tmp_path: Path):
+    def test_creates_parent_dirs(self, tmp_path: Path, _reset_oss_singleton):
         mock_client = MagicMock()
         mock_client.file_exists.return_value = True
 
@@ -581,18 +592,18 @@ class TestTryOssDownload:
             "dojozero.utils.oss.OSSClient.from_env",
             return_value=mock_client,
         ):
-            from dojozero.dashboard_server._server import _try_oss_download
+            from dojozero.dashboard_server._trial_manager import download_trial_from_oss
 
             cache_path = tmp_path / "deep" / "nested" / "events.jsonl"
-            _try_oss_download("trial-123", cache_path)
+            download_trial_from_oss("trial-123", cache_path)
 
         assert cache_path.parent.exists()
 
 
-class TestTryOssUpload:
-    """Tests for _try_oss_upload server helper."""
+class TestUploadTrialToOss:
+    """Tests for upload_trial_to_oss helper."""
 
-    def test_uploads_file(self, tmp_path: Path):
+    def test_uploads_file(self, tmp_path: Path, _reset_oss_singleton):
         local_file = tmp_path / "events.jsonl"
         local_file.write_text('{"event": "test"}\n')
 
@@ -602,29 +613,49 @@ class TestTryOssUpload:
             "dojozero.utils.oss.OSSClient.from_env",
             return_value=mock_client,
         ):
-            from dojozero.dashboard_server._server import _try_oss_upload
+            from dojozero.dashboard_server._trial_manager import upload_trial_to_oss
 
-            _try_oss_upload("trial-123", local_file)
+            result = upload_trial_to_oss("trial-123", local_file)
 
+        assert result is True
         mock_client.upload_file.assert_called_once_with(
             local_file, "trials/trial-123/events.jsonl"
         )
 
-    def test_silently_handles_import_error(self, tmp_path: Path):
+    def test_returns_false_for_missing_file(self, tmp_path: Path):
+        from dojozero.dashboard_server._trial_manager import upload_trial_to_oss
+
+        result = upload_trial_to_oss("trial-123", tmp_path / "nonexistent.jsonl")
+        assert result is False
+
+    def test_returns_false_for_none(self):
+        from dojozero.dashboard_server._trial_manager import upload_trial_to_oss
+
+        result = upload_trial_to_oss("trial-123", None)
+        assert result is False
+
+    def test_silently_handles_import_error(self, tmp_path: Path, _reset_oss_singleton):
+        local_file = tmp_path / "events.jsonl"
+        local_file.write_text('{"event": "test"}\n')
+
         with patch(
             "dojozero.utils.oss.OSSClient.from_env",
             side_effect=ImportError("no oss2"),
         ):
-            from dojozero.dashboard_server._server import _try_oss_upload
+            from dojozero.dashboard_server._trial_manager import upload_trial_to_oss
 
-            # Should not raise
-            _try_oss_upload("trial-123", tmp_path / "events.jsonl")
+            result = upload_trial_to_oss("trial-123", local_file)
 
-    def test_silently_handles_value_error(self, tmp_path: Path):
+        assert result is False
+
+    def test_silently_handles_value_error(self, tmp_path: Path, _reset_oss_singleton):
+        local_file = tmp_path / "events.jsonl"
+        local_file.write_text('{"event": "test"}\n')
+
         with patch(
             "dojozero.utils.oss.OSSClient.from_env",
             side_effect=ValueError("missing env"),
         ):
-            from dojozero.dashboard_server._server import _try_oss_upload
+            from dojozero.dashboard_server._trial_manager import upload_trial_to_oss
 
-            _try_oss_upload("trial-123", tmp_path / "events.jsonl")
+            assert upload_trial_to_oss("trial-123", local_file) is False

--- a/packages/dojozero/tests/test_scheduler.py
+++ b/packages/dojozero/tests/test_scheduler.py
@@ -452,7 +452,7 @@ class TestTrialSource:
             pre_start_hours=2.0,
             check_interval_seconds=60.0,
             auto_stop_on_completion=True,
-            data_dir="outputs",
+            output_dir="outputs",
         )
 
         source = TrialSource(
@@ -484,7 +484,7 @@ class TestTrialSource:
                 "pre_start_hours": 1.0,
                 "check_interval_seconds": 30.0,
                 "auto_stop_on_completion": True,
-                "data_dir": "outputs",
+                "output_dir": "outputs",
             },
             "enabled": True,
             "created_at": now.isoformat(),

--- a/trial_sources/base/nba.yaml
+++ b/trial_sources/base/nba.yaml
@@ -63,5 +63,4 @@ schedule:
   pre_start_hours: 0.1
   check_interval_seconds: 60.0
   auto_stop_on_completion: true
-  data_dir: outputs
   sync_interval_seconds: 3600.0

--- a/trial_sources/base/ncaa.yaml
+++ b/trial_sources/base/ncaa.yaml
@@ -62,5 +62,4 @@ schedule:
   pre_start_hours: 0.1
   check_interval_seconds: 60.0
   auto_stop_on_completion: true
-  data_dir: outputs
   sync_interval_seconds: 3600.0

--- a/trial_sources/base/nfl.yaml
+++ b/trial_sources/base/nfl.yaml
@@ -62,5 +62,4 @@ schedule:
   pre_start_hours: 0.1
   check_interval_seconds: 60.0
   auto_stop_on_completion: true
-  data_dir: outputs
   sync_interval_seconds: 3600.0

--- a/trial_sources/daily/nba.yaml
+++ b/trial_sources/daily/nba.yaml
@@ -6,4 +6,4 @@ config:
   scenario_name: nba
   max_daily_games: 1
   personas: [degen]
-  llm_config_path: agents/llms/claude.yaml
+  llm_config_path: agents/llms/default.yaml

--- a/trial_sources/daily/ncaa.yaml
+++ b/trial_sources/daily/ncaa.yaml
@@ -6,4 +6,4 @@ config:
   scenario_name: ncaa
   max_daily_games: 1
   personas: [degen]
-  llm_config_path: agents/llms/claude.yaml
+  llm_config_path: agents/llms/default.yaml

--- a/trial_sources/daily/nfl.yaml
+++ b/trial_sources/daily/nfl.yaml
@@ -6,4 +6,4 @@ config:
   scenario_name: nfl
   max_daily_games: 1
   personas: [degen]
-  llm_config_path: agents/llms/claude.yaml
+  llm_config_path: agents/llms/default.yaml


### PR DESCRIPTION
### Summary
- Consolidate data_dir → output_dir: Single source of truth via dojo0 serve --output-dir, with per-source override. Remove redundant data_dir from trial source configs and server state.
- Fix OSS backup: Add region auto-extraction for oss2 v4 signatures, ensure all trial completion paths (natural, resumed, scheduled) trigger OSS upload, use singleton OSSClient.
- Unified outputs/trials/ cache: Replace outputs/backtest_cache/ with outputs/trials/{trial_id}.jsonl as the canonical trial-id-indexed local cache. Live trials get relative symlinks; OSS/SLS-fetched files are written directly. Dangling symlinks auto-clean on next
access.
- OSS as priority resolution: Download and backtest endpoints now check outputs/trials/ → OSS → peer proxy → SLS (with upload to OSS after materialization). OSS is checked before peer proxy for completed trials.
- Fix daily trial sources: Update trial_sources/daily/*.yaml to reference agents/llms/default.yaml.

###  Key changes
- _trial_manager.py: trials_cache_path(), ensure_trial_symlink(), download_trial_from_oss(), singleton _get_oss_client()
- _server.py: Simplified download/backtest resolution chain, dangling symlink cleanup
- _scheduler.py: Creates symlink on local trial launch
- oss.py: _extract_region() for v4 signature region auto-detection
- cli.py: --output-dir defaults to Path("outputs")

###  Test plan
- [x] All 836 tests pass
- [x] _extract_region tested for standard, internal, scheme, port variants
- [x] download_trial_from_oss / upload_trial_to_oss tested (success, not found, ImportError, ValueError)
- [x] trials_cache_path tested (with/without run_id)
- [x] ensure_trial_symlink tested (create, relative path, idempotent, no-clobber, stale replacement)
- [x] Deploy to pre-prod: verify scheduled trials upload to OSS, backtest uses OSS resolution