### PR TITLE
better external agent support

### DIFF
--- a/demos/external_agent/robust_agent.py
+++ b/demos/external_agent/robust_agent.py
@@ -228,13 +228,23 @@ class RobustBettingAgent:
 
         while self._running:
             try:
-                events = await trial.poll_events(
+                result = await trial.poll_events(
                     since=self.state.last_sequence,
                     limit=50,
                 )
 
-                for event in events:
+                for event in result.events:
                     await self._handle_event(trial, event)
+
+                if result.is_trial_ended:
+                    reason = (
+                        result.trial_ended.get("reason", "completed")
+                        if result.trial_ended
+                        else "completed"
+                    )
+                    logger.info("Trial ended (reason=%s)", reason)
+                    self._running = False
+                    return
 
                 await asyncio.sleep(self.poll_interval)
 

--- a/demos/external_agent/robust_agent.py
+++ b/demos/external_agent/robust_agent.py
@@ -105,7 +105,7 @@ class RobustBettingAgent:
         bet_threshold: float = 0.55,
         max_reconnect_attempts: int = 10,
         reconnect_delay: float = 5.0,
-        poll_interval: float = 2.0,
+        poll_interval: float = 5.0,
     ):
         """Initialize the agent.
 

--- a/packages/dojozero-client/pyproject.toml
+++ b/packages/dojozero-client/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dojozero-client"
-version = "0.2.2"
+version = "0.3.0"
 description = "Python SDK for external agents participating in DojoZero trials. Works with OpenClaw and QwenPaw."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/dojozero-client/src/dojozero_client/__init__.py
+++ b/packages/dojozero-client/src/dojozero_client/__init__.py
@@ -27,6 +27,7 @@ from dojozero_client._client import (
     GatewayInfo,
     Holding,
     Odds,
+    PollResult,
     TrialConnection,
     TrialEndedEvent,
     TrialMetadata,
@@ -60,7 +61,7 @@ from dojozero_client._exceptions import (
 )
 from dojozero_client._transport import GatewayTransport, SSEEvent
 
-__version__ = "0.1.0"
+__version__ = "0.3.0"
 
 __all__ = [
     # Main client
@@ -74,6 +75,7 @@ __all__ = [
     "GatewayInfo",
     "Holding",
     "Odds",
+    "PollResult",
     "TrialEndedEvent",
     "TrialMetadata",
     "TrialResults",

--- a/packages/dojozero-client/src/dojozero_client/_client.py
+++ b/packages/dojozero-client/src/dojozero_client/_client.py
@@ -463,15 +463,13 @@ class TrialConnection:
     async def poll_events(
         self,
         since: int | None = None,
-        limit: int = 50,
-        event_types: list[str] | None = None,
+        limit: int = 100,
     ) -> "PollResult":
         """Poll for recent events.
 
         Args:
             since: Get events after this sequence number
-            limit: Maximum events to return
-            event_types: Optional event type filter
+            limit: Maximum events to return (max 100)
 
         Returns:
             PollResult with events and trial_ended info
@@ -479,8 +477,6 @@ class TrialConnection:
         params: dict[str, Any] = {"limit": limit}
         if since is not None:
             params["since"] = since
-        if event_types:
-            params["event_types"] = ",".join(event_types)
 
         response = await self._transport.request(
             "GET",

--- a/packages/dojozero-client/src/dojozero_client/_client.py
+++ b/packages/dojozero-client/src/dojozero_client/_client.py
@@ -262,6 +262,19 @@ class TrialResults:
         )
 
 
+@dataclass
+class PollResult:
+    """Result of a poll_events call."""
+
+    events: list[EventEnvelope]
+    trial_ended: dict[str, Any] | None = None
+
+    @property
+    def is_trial_ended(self) -> bool:
+        """Check if trial has ended."""
+        return self.trial_ended is not None
+
+
 class TrialConnection:
     """Connection to a specific trial.
 
@@ -452,7 +465,7 @@ class TrialConnection:
         since: int | None = None,
         limit: int = 50,
         event_types: list[str] | None = None,
-    ) -> list[EventEnvelope]:
+    ) -> "PollResult":
         """Poll for recent events.
 
         Args:
@@ -461,7 +474,7 @@ class TrialConnection:
             event_types: Optional event type filter
 
         Returns:
-            List of EventEnvelope objects
+            PollResult with events and trial_ended info
         """
         params: dict[str, Any] = {"limit": limit}
         if since is not None:
@@ -482,7 +495,10 @@ class TrialConnection:
         if current_seq > self._last_sequence:
             self._last_sequence = current_seq
 
-        return events
+        # Check for trial ended
+        trial_ended = response.get("trialEnded")
+
+        return PollResult(events=events, trial_ended=trial_ended)
 
     async def get_current_odds(self) -> Odds:
         """Get current betting odds.
@@ -880,6 +896,7 @@ __all__ = [
     "EventEnvelope",
     "GatewayInfo",
     "Odds",
+    "PollResult",
     "TrialConnection",
     "TrialEndedEvent",
     "TrialMetadata",

--- a/packages/dojozero-client/src/dojozero_client/_daemon.py
+++ b/packages/dojozero-client/src/dojozero_client/_daemon.py
@@ -18,7 +18,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from dojozero_client._client import AgentResult, DojoClient, EventEnvelope
+from dojozero_client._client import AgentResult, DojoClient, EventEnvelope, PollResult
 from dojozero_client._config import (
     CONFIG_DIR,
     PID_FILE,
@@ -550,43 +550,82 @@ class TrialHandler:
         return events
 
     async def _event_loop(self) -> None:
-        """Main event processing loop."""
+        """Main event processing loop using polling."""
         if not self._trial:
             return
 
-        try:
-            async for event in self._trial.events(
-                event_types=self.filters,
-                raise_on_trial_end=False,
-            ):
-                if not self._running:
-                    break
-                await self._handle_event(event)
+        poll_interval = float(os.environ.get("DOJOZERO_POLL_INTERVAL", "2.0"))
 
-            # Check if trial ended naturally
-            if self._trial.trial_ended is not None:
-                ended = self._trial.trial_ended
-                logger.info(
-                    "Trial %s ended (reason=%s, agents=%d)",
-                    self.trial_id,
-                    ended.reason,
-                    len(ended.final_results),
-                )
-                self._state.status = ended.reason
-                if ended.final_results:
-                    _write_results(
-                        self.state_dir / "results.json",
-                        self.trial_id,
-                        ended.reason,
-                        ended.final_results,
+        try:
+            while self._running:
+                try:
+                    result: PollResult = await self._trial.poll_events(
+                        since=self._state.last_event_sequence,
+                        event_types=self.filters,
                     )
-                self._save_state()
+                except Exception as e:
+                    # 404 or connection error means gateway is gone
+                    logger.info(
+                        "Trial %s: Poll failed (%s), treating as trial ended",
+                        self.trial_id,
+                        e,
+                    )
+                    await self._handle_trial_ended("completed", [])
+                    return
+
+                for event in result.events:
+                    if not self._running:
+                        return
+                    await self._handle_event(event)
+
+                if result.is_trial_ended:
+                    reason = (
+                        result.trial_ended.get("reason", "completed")
+                        if result.trial_ended
+                        else "completed"
+                    )
+                    logger.info("Trial %s ended (reason=%s)", self.trial_id, reason)
+                    # Fetch final results from server
+                    try:
+                        results_resp = await self._trial.get_results()
+                        final_results = [
+                            AgentResult(
+                                agent_id=r.agent_id,
+                                final_balance=r.final_balance,
+                                net_profit=r.net_profit,
+                                total_bets=r.total_bets,
+                                win_rate=r.win_rate,
+                                roi=r.roi,
+                            )
+                            for r in results_resp.results
+                        ]
+                    except Exception:
+                        final_results = []
+                    await self._handle_trial_ended(reason, final_results)
+                    return
+
+                await asyncio.sleep(poll_interval)
+
         except asyncio.CancelledError:
             pass
         except Exception as e:
             logger.exception("Trial %s: Event loop error: %s", self.trial_id, e)
             self._state.status = "error"
             self._save_state()
+
+    async def _handle_trial_ended(
+        self, reason: str, final_results: list[AgentResult]
+    ) -> None:
+        """Handle trial ended — write results and update state."""
+        self._state.status = reason
+        if final_results:
+            _write_results(
+                self.state_dir / "results.json",
+                self.trial_id,
+                reason,
+                final_results,
+            )
+        self._save_state()
 
     async def _handle_event(self, event: EventEnvelope) -> None:
         """Process an incoming event."""

--- a/packages/dojozero-client/src/dojozero_client/_daemon.py
+++ b/packages/dojozero-client/src/dojozero_client/_daemon.py
@@ -554,14 +554,13 @@ class TrialHandler:
         if not self._trial:
             return
 
-        poll_interval = float(os.environ.get("DOJOZERO_POLL_INTERVAL", "2.0"))
+        poll_interval = float(os.environ.get("DOJOZERO_POLL_INTERVAL", "5.0"))
 
         try:
             while self._running:
                 try:
                     result: PollResult = await self._trial.poll_events(
                         since=self._state.last_event_sequence,
-                        event_types=self.filters,
                     )
                 except Exception as e:
                     # 404 or connection error means gateway is gone
@@ -604,7 +603,10 @@ class TrialHandler:
                     await self._handle_trial_ended(reason, final_results)
                     return
 
-                await asyncio.sleep(poll_interval)
+                # If we got a full page, there may be more — poll again
+                # immediately to catch up. Otherwise wait before next poll.
+                if len(result.events) < 100:
+                    await asyncio.sleep(poll_interval)
 
         except asyncio.CancelledError:
             pass

--- a/packages/dojozero-client/src/dojozero_client/_daemon.py
+++ b/packages/dojozero-client/src/dojozero_client/_daemon.py
@@ -627,6 +627,11 @@ class TrialHandler:
                 reason,
                 final_results,
             )
+            # Update balance from our own settled result
+            for r in final_results:
+                if r.agent_id == self.agent_id:
+                    self._state.balance = r.final_balance
+                    break
         self._save_state()
 
     async def _handle_event(self, event: EventEnvelope) -> None:

--- a/packages/dojozero-client/tests/test_daemon.py
+++ b/packages/dojozero-client/tests/test_daemon.py
@@ -9,7 +9,12 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from dojozero_client._client import AgentResult, EventEnvelope, TrialEndedEvent
+from dojozero_client._client import (
+    AgentResult,
+    EventEnvelope,
+    PollResult,
+    TrialResults,
+)
 from dojozero_client._daemon import (
     DaemonState,
     TrialHandler,
@@ -273,24 +278,8 @@ def _make_agent_result(**overrides: object) -> AgentResult:
     return AgentResult(**defaults)  # type: ignore[arg-type]
 
 
-def _make_trial_ended(
-    reason: str = "completed",
-    results: list[AgentResult] | None = None,
-) -> TrialEndedEvent:
-    """Create a TrialEndedEvent with sensible defaults."""
-    if results is None:
-        results = [_make_agent_result()]
-    return TrialEndedEvent(
-        trial_id="test-trial",
-        reason=reason,
-        timestamp=datetime.now(timezone.utc),
-        final_results=results,
-        message=f"Trial has {reason}",
-    )
-
-
 class TestTrialHandlerTrialEnd:
-    """Tests for TrialHandler handling trial_ended events."""
+    """Tests for TrialHandler handling trial_ended via polling."""
 
     @pytest.mark.asyncio
     async def test_event_loop_handles_completed_trial(self):
@@ -306,21 +295,40 @@ class TestTrialHandlerTrialEnd:
                 handler._state.status = "connected"
                 handler.state_dir.mkdir(parents=True, exist_ok=True)
 
-                # Mock trial that yields one event then ends
                 mock_trial = AsyncMock()
-                ended = _make_trial_ended("completed")
+                call_count = 0
 
-                async def mock_events(**kwargs):
-                    event = EventEnvelope(
-                        trial_id="test-trial",
-                        sequence=1,
-                        timestamp=datetime.now(timezone.utc),
-                        payload={"event_type": "event.odds_update"},
+                async def mock_poll(**kwargs):
+                    nonlocal call_count
+                    call_count += 1
+                    if call_count == 1:
+                        # First poll: return an event
+                        return PollResult(
+                            events=[
+                                EventEnvelope(
+                                    trial_id="test-trial",
+                                    sequence=1,
+                                    timestamp=datetime.now(timezone.utc),
+                                    payload={"event_type": "event.odds_update"},
+                                )
+                            ],
+                        )
+                    # Second poll: trial ended
+                    return PollResult(
+                        events=[],
+                        trial_ended={"reason": "completed", "message": ""},
                     )
-                    yield event
 
-                mock_trial.events = mock_events
-                mock_trial.trial_ended = ended
+                agent_result = _make_agent_result()
+                mock_trial.poll_events = mock_poll
+                mock_trial.get_results = AsyncMock(
+                    return_value=TrialResults(
+                        trial_id="test-trial",
+                        status="completed",
+                        results=[agent_result],
+                        ended_at=datetime.now(timezone.utc),
+                    )
+                )
                 handler._trial = mock_trial
                 handler._running = True
 
@@ -353,14 +361,20 @@ class TestTrialHandlerTrialEnd:
                 handler.state_dir.mkdir(parents=True, exist_ok=True)
 
                 mock_trial = AsyncMock()
-                ended = _make_trial_ended("cancelled")
-
-                async def mock_events(**kwargs):
-                    return
-                    yield  # make it an async generator
-
-                mock_trial.events = mock_events
-                mock_trial.trial_ended = ended
+                mock_trial.poll_events = AsyncMock(
+                    return_value=PollResult(
+                        events=[],
+                        trial_ended={"reason": "cancelled", "message": ""},
+                    )
+                )
+                mock_trial.get_results = AsyncMock(
+                    return_value=TrialResults(
+                        trial_id="test-trial",
+                        status="cancelled",
+                        results=[],
+                        ended_at=None,
+                    )
+                )
                 handler._trial = mock_trial
                 handler._running = True
 
@@ -383,14 +397,20 @@ class TestTrialHandlerTrialEnd:
                 handler.state_dir.mkdir(parents=True, exist_ok=True)
 
                 mock_trial = AsyncMock()
-                ended = _make_trial_ended("failed", results=[])
-
-                async def mock_events(**kwargs):
-                    return
-                    yield
-
-                mock_trial.events = mock_events
-                mock_trial.trial_ended = ended
+                mock_trial.poll_events = AsyncMock(
+                    return_value=PollResult(
+                        events=[],
+                        trial_ended={"reason": "failed", "message": ""},
+                    )
+                )
+                mock_trial.get_results = AsyncMock(
+                    return_value=TrialResults(
+                        trial_id="test-trial",
+                        status="failed",
+                        results=[],
+                        ended_at=None,
+                    )
+                )
                 handler._trial = mock_trial
                 handler._running = True
 
@@ -401,8 +421,8 @@ class TestTrialHandlerTrialEnd:
                 assert not (handler.state_dir / "results.json").exists()
 
     @pytest.mark.asyncio
-    async def test_event_loop_no_trial_ended(self):
-        """Test event loop does not change status when stream ends without trial_ended."""
+    async def test_event_loop_gateway_404_treats_as_ended(self):
+        """Test poll failure (e.g. gateway 404) is treated as trial ended."""
         with tempfile.TemporaryDirectory() as tmpdir:
             with patch("dojozero_client._daemon.TRIALS_DIR", Path(tmpdir)):
                 client = MagicMock()
@@ -415,25 +435,19 @@ class TestTrialHandlerTrialEnd:
                 handler.state_dir.mkdir(parents=True, exist_ok=True)
 
                 mock_trial = AsyncMock()
-
-                async def mock_events(**kwargs):
-                    return
-                    yield
-
-                mock_trial.events = mock_events
-                mock_trial.trial_ended = None  # No trial_ended event
+                mock_trial.poll_events = AsyncMock(
+                    side_effect=Exception("404 Not Found")
+                )
                 handler._trial = mock_trial
                 handler._running = True
 
                 await handler._event_loop()
 
-                # Status should not be changed by event loop
-                assert handler._state.status == "connected"
-                assert not (handler.state_dir / "results.json").exists()
+                assert handler._state.status == "completed"
 
     @pytest.mark.asyncio
     async def test_event_loop_real_error_sets_error_status(self):
-        """Test real exceptions still set status=error."""
+        """Test unhandled exceptions in event processing set status=error."""
         with tempfile.TemporaryDirectory() as tmpdir:
             with patch("dojozero_client._daemon.TRIALS_DIR", Path(tmpdir)):
                 client = MagicMock()
@@ -446,15 +460,25 @@ class TestTrialHandlerTrialEnd:
                 handler.state_dir.mkdir(parents=True, exist_ok=True)
 
                 mock_trial = AsyncMock()
-
-                async def mock_events(**kwargs):
-                    raise ConnectionError("Network failed")
-                    yield  # make it an async generator
-
-                mock_trial.events = mock_events
-                mock_trial.trial_ended = None
+                mock_trial.poll_events = AsyncMock(
+                    return_value=PollResult(
+                        events=[
+                            EventEnvelope(
+                                trial_id="test-trial",
+                                sequence=1,
+                                timestamp=datetime.now(timezone.utc),
+                                payload={"event_type": "event.test"},
+                            )
+                        ],
+                    )
+                )
                 handler._trial = mock_trial
                 handler._running = True
+
+                # Make _handle_event raise to trigger error path
+                handler._handle_event = AsyncMock(
+                    side_effect=RuntimeError("Unexpected crash")
+                )
 
                 await handler._event_loop()
 
@@ -483,16 +507,22 @@ class TestTrialHandlerTrialEnd:
                         roi=-0.2,
                     ),
                 ]
-                ended = _make_trial_ended("completed", results=results)
 
                 mock_trial = AsyncMock()
-
-                async def mock_events(**kwargs):
-                    return
-                    yield
-
-                mock_trial.events = mock_events
-                mock_trial.trial_ended = ended
+                mock_trial.poll_events = AsyncMock(
+                    return_value=PollResult(
+                        events=[],
+                        trial_ended={"reason": "completed", "message": ""},
+                    )
+                )
+                mock_trial.get_results = AsyncMock(
+                    return_value=TrialResults(
+                        trial_id="test-trial",
+                        status="completed",
+                        results=results,
+                        ended_at=datetime.now(timezone.utc),
+                    )
+                )
                 handler._trial = mock_trial
                 handler._running = True
 

--- a/packages/dojozero/src/dojozero/dashboard_server/_server.py
+++ b/packages/dojozero/src/dojozero/dashboard_server/_server.py
@@ -1236,6 +1236,15 @@ def create_dashboard_app(
         if results is not None:
             return JSONResponse(content=results)
 
+        # Try OSS fallback
+        from dojozero.dashboard_server._trial_manager import (
+            download_trial_file_from_oss,
+        )
+
+        oss_results = download_trial_file_from_oss(trial_id, "results.json")
+        if oss_results is not None:
+            return JSONResponse(content=oss_results)
+
         # Try to proxy to the owning peer in cluster mode
         if state.peer_registry is not None:
             try:

--- a/packages/dojozero/src/dojozero/dashboard_server/_server.py
+++ b/packages/dojozero/src/dojozero/dashboard_server/_server.py
@@ -2036,6 +2036,14 @@ async def run_dashboard_server(
         cluster_config=cluster_config,
     )
 
+    # Suppress noisy polling endpoint from access logs
+    class _PollFilter(logging.Filter):
+        def filter(self, record: logging.LogRecord) -> bool:
+            msg = record.getMessage()
+            return "/events/recent" not in msg
+
+    logging.getLogger("uvicorn.access").addFilter(_PollFilter())
+
     config = uvicorn.Config(
         app,
         host=host,

--- a/packages/dojozero/src/dojozero/dashboard_server/_trial_manager.py
+++ b/packages/dojozero/src/dojozero/dashboard_server/_trial_manager.py
@@ -1054,10 +1054,6 @@ class TrialManager:
             except Exception as e:
                 self._logger.error("Error stopping trial %s: %s", trial_id, e)
 
-            # Upload to OSS after stopping (before returning)
-            if self._oss_backup and final_phase == QueuedTrialPhase.COMPLETED:
-                self._upload_to_oss(trial_id, queued.spec)
-
             return True
 
         return False
@@ -1218,9 +1214,6 @@ class TrialManager:
             except TrialNotFoundError:
                 queued.phase = QueuedTrialPhase.COMPLETED
 
-            if self._oss_backup and queued.phase == QueuedTrialPhase.COMPLETED:
-                self._upload_to_oss(trial_id, queued.spec)
-
             self._logger.info(
                 "Resumed trial '%s' finished with phase: %s",
                 trial_id,
@@ -1269,6 +1262,10 @@ class TrialManager:
             # (cancelled trials that are still running won't have phase updated)
             if queued.phase != QueuedTrialPhase.RUNNING:
                 await self._save_trial_results(trial_id, queued.phase)
+
+            # Upload to OSS after saving results but before gateway teardown
+            if self._oss_backup and queued.phase == QueuedTrialPhase.COMPLETED:
+                self._upload_to_oss(trial_id, queued.spec)
 
             # Clean up gateway if registered
             if self._gateway_router is not None:
@@ -1392,9 +1389,6 @@ class TrialManager:
             except TrialNotFoundError:
                 queued.phase = QueuedTrialPhase.COMPLETED
 
-            if self._oss_backup and queued.phase == QueuedTrialPhase.COMPLETED:
-                self._upload_to_oss(trial_id, queued.spec)
-
             self._logger.info(
                 "Trial '%s' finished with phase: %s", trial_id, queued.phase.value
             )
@@ -1441,6 +1435,11 @@ class TrialManager:
                 # Save trial results (for ALL trials, not just gateway)
                 # Must happen BEFORE gateway cleanup since we need access to broker
                 await self._save_trial_results(trial_id, queued.phase)
+
+            # Upload to OSS after saving results but before gateway teardown
+            # so that results.json is durable before agents lose access
+            if self._oss_backup and queued.phase == QueuedTrialPhase.COMPLETED:
+                self._upload_to_oss(trial_id, queued.spec)
 
             # Signal trial ended and unregister gateway (gateway-specific cleanup)
             if gateway_registered:

--- a/packages/dojozero/src/dojozero/dashboard_server/_trial_manager.py
+++ b/packages/dojozero/src/dojozero/dashboard_server/_trial_manager.py
@@ -23,6 +23,7 @@ from dojozero.core import (
     TrialSpec,
     TrialStatus,
 )
+from dojozero.core._filesystem_orchestrator_store import FileSystemOrchestratorStore
 from dojozero.dashboard_server._jsonl_utils import (
     extract_game_result_from_jsonl,
     get_jsonl_last_modified,
@@ -1446,11 +1447,24 @@ class TrialManager:
                 await self._signal_trial_ended_and_cleanup(trial_id, queued.phase)
 
     def _upload_to_oss(self, trial_id: str, spec: TrialSpec) -> None:
-        """Upload trial data to OSS if configured."""
+        """Upload trial data to OSS if configured.
+
+        Uploads events.jsonl (from persistence file), results.json, and
+        spec.json (from orchestrator store).
+        """
         persistence_file_path = spec.metadata.get("persistence_file")
         if persistence_file_path and isinstance(persistence_file_path, str):
             persistence_file = Path(persistence_file_path)
             upload_trial_to_oss(trial_id, persistence_file)
+
+        # Upload results.json and spec.json from the orchestrator store
+        store = self._orchestrator.store
+        if isinstance(store, FileSystemOrchestratorStore):
+            trial_dir = store._trial_dir(trial_id)
+            for filename in ("results.json", "spec.json"):
+                filepath = trial_dir / filename
+                if filepath.exists():
+                    _upload_file_to_oss(trial_id, filepath, filename)
 
 
 # ---------------------------------------------------------------------------
@@ -1501,9 +1515,15 @@ def ensure_trial_symlink(
 _oss_client = None
 
 
-def _oss_trial_key(trial_id: str) -> str:
-    """OSS object key for a trial's event file."""
-    return f"trials/{trial_id}/events.jsonl"
+def _oss_trial_key(trial_id: str, filename: str = "events.jsonl") -> str:
+    """OSS object key for a trial file.
+
+    Args:
+        trial_id: Trial identifier
+        filename: File name within the trial directory (e.g. "events.jsonl",
+                  "results.json", "spec.json")
+    """
+    return f"trials/{trial_id}/{filename}"
 
 
 def _get_oss_client():  # noqa: ANN202
@@ -1555,6 +1575,36 @@ def upload_trial_to_oss(trial_id: str, persistence_file: Path | None) -> bool:
         return False
 
 
+def _upload_file_to_oss(trial_id: str, filepath: Path, filename: str) -> bool:
+    """Upload a single file to OSS under the trial's directory.
+
+    Args:
+        trial_id: Trial identifier
+        filepath: Local path to the file
+        filename: Target filename in OSS (e.g. "results.json")
+
+    Returns:
+        True if upload succeeded, False otherwise
+    """
+    if not filepath.exists():
+        return False
+    try:
+        client = _get_oss_client()
+        oss_key = _oss_trial_key(trial_id, filename)
+        full_key = client.upload_file(filepath, oss_key)
+        LOGGER.info("Uploaded %s to OSS: %s", filename, full_key)
+        return True
+    except ImportError:
+        return False
+    except ValueError:
+        return False
+    except Exception as e:
+        LOGGER.debug(
+            "OSS upload of %s failed for trial '%s': %s", filename, trial_id, e
+        )
+        return False
+
+
 def download_trial_from_oss(trial_id: str, cache_path: Path) -> bool:
     """Download a trial's event file from OSS to a local cache path.
 
@@ -1580,10 +1630,47 @@ def download_trial_from_oss(trial_id: str, cache_path: Path) -> bool:
         return False
 
 
+def download_trial_file_from_oss(
+    trial_id: str, filename: str = "results.json"
+) -> dict[str, Any] | None:
+    """Download a trial JSON file from OSS and return parsed contents.
+
+    Args:
+        trial_id: Trial identifier
+        filename: File to download (e.g. "results.json", "spec.json")
+
+    Returns:
+        Parsed JSON dict, or None if not found / download failed.
+    """
+    import json
+    import tempfile
+
+    try:
+        client = _get_oss_client()
+        oss_key = _oss_trial_key(trial_id, filename)
+        if not client.file_exists(oss_key):
+            return None
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_path = Path(tmpdir) / filename
+            client.download_file(oss_key, tmp_path)
+            with open(tmp_path, encoding="utf-8") as f:
+                return json.load(f)
+    except ImportError:
+        return None
+    except ValueError:
+        return None
+    except Exception as e:
+        LOGGER.debug(
+            "OSS download of %s failed for trial '%s': %s", filename, trial_id, e
+        )
+        return None
+
+
 __all__ = [
     "QueuedTrial",
     "QueuedTrialPhase",
     "TrialManager",
+    "download_trial_file_from_oss",
     "download_trial_from_oss",
     "ensure_trial_symlink",
     "trials_cache_path",

--- a/packages/dojozero/src/dojozero/data/_hub.py
+++ b/packages/dojozero/src/dojozero/data/_hub.py
@@ -99,7 +99,7 @@ class DataHub:
 
         # Subscription manager handles all subscription logic
         self._subscription_manager = SubscriptionManager(
-            max_recent_events_per_type=100,
+            max_recent_events_per_type=10_000,
         )
 
         # Backward compatibility: maintain the original _agent_subscriptions structure
@@ -575,6 +575,20 @@ class DataHub:
             List of recent events (newest first)
         """
         return self._subscription_manager.get_recent_events(event_types, limit)
+
+    def get_events_since(
+        self, since: int, limit: int = 100
+    ) -> list[tuple[int, "DataEvent"]]:
+        """Get events with sequence > since, ordered by sequence ascending.
+
+        Args:
+            since: Return events after this sequence number (0 = from start)
+            limit: Maximum number of events to return
+
+        Returns:
+            List of (sequence, event) tuples, oldest first
+        """
+        return self._subscription_manager.get_events_since(since, limit)
 
     async def _persist_event(self, event: DataEvent) -> None:
         """Persist event to file.

--- a/packages/dojozero/src/dojozero/data/_stores.py
+++ b/packages/dojozero/src/dojozero/data/_stores.py
@@ -456,13 +456,20 @@ class DataStore(ABC):
             except Exception as e:
                 logger.error("Error in poll loop for store %s: %s", self.store_id, e)
 
-            # Wait before next poll - read interval dynamically to support runtime updates
-            # Recalculate minimum interval on each iteration (in case it was updated)
-            if self.poll_intervals:
-                loop_interval = min(self.poll_intervals.values())
-            else:
-                loop_interval = self.poll_interval_seconds
-            await asyncio.sleep(loop_interval)
+            # Wait before next poll — sleep in short ticks so we react
+            # quickly when the interval is reduced at runtime (e.g. pre-game
+            # 300s → in-game 5s after a game_start event).
+            elapsed = 0.0
+            tick = 1.0  # check every second
+            while self._running:
+                if self.poll_intervals:
+                    target = min(self.poll_intervals.values())
+                else:
+                    target = self.poll_interval_seconds
+                if elapsed >= target:
+                    break
+                await asyncio.sleep(min(tick, target - elapsed))
+                elapsed += tick
 
     async def _poll_api(
         self,

--- a/packages/dojozero/src/dojozero/data/_subscriptions.py
+++ b/packages/dojozero/src/dojozero/data/_subscriptions.py
@@ -231,7 +231,7 @@ class SubscriptionManager:
 
     def __init__(
         self,
-        max_recent_events_per_type: int = 100,
+        max_recent_events_per_type: int = 10_000,
     ):
         """Initialize SubscriptionManager.
 
@@ -245,6 +245,10 @@ class SubscriptionManager:
         # Recent events cache for late-joining subscribers
         self._recent_events: dict[str, list["DataEvent"]] = defaultdict(list)
         self._max_recent_events_per_type = max_recent_events_per_type
+
+        # Sequential cache: ordered list of (sequence, event) for polling pagination
+        self._sequential_cache: list[tuple[int, "DataEvent"]] = []
+        self._max_sequential_cache = max_recent_events_per_type
 
         # Legacy callback support (for backward compatibility with DataHub.subscribe_agent)
         self._event_handlers: dict[str, list[Callable[["DataEvent"], None]]] = (
@@ -423,11 +427,11 @@ class SubscriptionManager:
         Returns:
             Number of subscriptions that received the event
         """
-        # Cache for late joiners
-        self._cache_event(event)
-
-        # Increment global sequence
+        # Increment global sequence first so cache stores the real sequence
         self._global_sequence += 1
+
+        # Cache for late joiners (with real sequence number)
+        self._cache_event(event, self._global_sequence)
 
         delivered = 0
         event_type = event.event_type
@@ -449,7 +453,7 @@ class SubscriptionManager:
 
         return delivered
 
-    def _cache_event(self, event: "DataEvent") -> None:
+    def _cache_event(self, event: "DataEvent", sequence: int = 0) -> None:
         """Cache event for late-joining subscribers."""
         event_type = event.event_type
         events_list = self._recent_events[event_type]
@@ -459,6 +463,14 @@ class SubscriptionManager:
             self._recent_events[event_type] = events_list[
                 : self._max_recent_events_per_type
             ]
+
+        # Also store in sequential cache with real sequence number
+        if sequence > 0:
+            self._sequential_cache.append((sequence, event))
+            if len(self._sequential_cache) > self._max_sequential_cache:
+                self._sequential_cache = self._sequential_cache[
+                    -self._max_sequential_cache :
+                ]
 
     def get_recent_events(
         self,
@@ -487,6 +499,30 @@ class SubscriptionManager:
                     result.extend(self._recent_events[event_type])
             result.sort(key=lambda e: e.timestamp, reverse=True)
             return result[:limit]
+
+    def get_events_since(
+        self, since: int, limit: int = 100
+    ) -> list[tuple[int, "DataEvent"]]:
+        """Get events with sequence > since, ordered by sequence ascending.
+
+        Uses the sequential cache for accurate sequence-based pagination.
+
+        Args:
+            since: Return events after this sequence number (0 = from start)
+            limit: Maximum number of events to return
+
+        Returns:
+            List of (sequence, event) tuples, oldest first
+        """
+        # Binary search for the starting position
+        lo, hi = 0, len(self._sequential_cache)
+        while lo < hi:
+            mid = (lo + hi) // 2
+            if self._sequential_cache[mid][0] <= since:
+                lo = mid + 1
+            else:
+                hi = mid
+        return self._sequential_cache[lo : lo + limit]
 
     @property
     def global_sequence(self) -> int:
@@ -551,11 +587,11 @@ class SubscriptionManager:
         Returns:
             Number of subscriptions that received the event
         """
-        # Cache for late joiners
-        self._cache_event(event)
-
-        # Increment global sequence
+        # Increment global sequence first so cache stores the real sequence
         self._global_sequence += 1
+
+        # Cache for late joiners (with real sequence number)
+        self._cache_event(event, self._global_sequence)
 
         delivered = 0
         event_type = event.event_type

--- a/packages/dojozero/src/dojozero/gateway/__init__.py
+++ b/packages/dojozero/src/dojozero/gateway/__init__.py
@@ -34,6 +34,7 @@ from dojozero.gateway._models import (
     RecentEventsResponse,
     SpreadLine,
     TotalLine,
+    TrialEndedInfo,
     TrialEndedMessage,
     TrialMetadataResponse,
     TrialResultsResponse,
@@ -85,6 +86,7 @@ __all__ = [
     "EventEnvelope",
     "HeartbeatMessage",
     "RecentEventsResponse",
+    "TrialEndedInfo",
     "TrialEndedMessage",
     "TrialResultsResponse",
     # Models - Odds

--- a/packages/dojozero/src/dojozero/gateway/_models.py
+++ b/packages/dojozero/src/dojozero/gateway/_models.py
@@ -122,6 +122,15 @@ class EventEnvelope(BaseModel):
     payload: dict[str, Any]
 
 
+class TrialEndedInfo(BaseModel):
+    """Lightweight trial-ended payload included in polling responses."""
+
+    model_config = ConfigDict(frozen=True, populate_by_name=True)
+
+    reason: str  # "completed", "cancelled", "failed"
+    message: str = ""
+
+
 class RecentEventsResponse(BaseModel):
     """Response for recent events polling."""
 
@@ -129,6 +138,9 @@ class RecentEventsResponse(BaseModel):
 
     events: list[EventEnvelope]
     current_sequence: int = Field(serialization_alias="currentSequence")
+    trial_ended: TrialEndedInfo | None = Field(
+        default=None, serialization_alias="trialEnded"
+    )
 
 
 # ============================================================================

--- a/packages/dojozero/src/dojozero/gateway/_server.py
+++ b/packages/dojozero/src/dojozero/gateway/_server.py
@@ -431,55 +431,33 @@ def create_gateway_app(
         since: int | None = Query(
             default=None, description="Sequence number to get events since"
         ),
-        limit: int = Query(default=50, le=100),
-        event_types: str | None = Query(default=None),
+        limit: int = Query(default=100, le=100),
         state: GatewayState = Depends(get_gateway_state),
     ) -> RecentEventsResponse:
-        """Get recent events (polling fallback).
+        """Get recent events via polling with pagination.
 
-        When `since` is provided, only returns events with sequence > since.
-        This allows efficient polling by requesting only new events.
+        Returns events with sequence > since, ordered oldest-first.
+        Client should keep polling while len(events) == limit to catch up.
         """
         if not state.adapter.is_registered(agent_id):
             raise HTTPException(status_code=403, detail="Agent not registered")
 
-        # Parse event types filter
-        filter_types = None
-        if event_types:
-            filter_types = [t.strip() for t in event_types.split(",")]
-
-        # Get current sequence first
         current_sequence = state.data_hub.subscription_manager.global_sequence
 
-        # If since >= current_sequence, no new events
-        if since is not None and since >= current_sequence:
-            return RecentEventsResponse(
-                events=[],
-                current_sequence=current_sequence,
-            )
+        # Get events from sequential cache with real sequence numbers
+        since_seq = since if since is not None else 0
+        sequenced_events = state.data_hub.get_events_since(since=since_seq, limit=limit)
 
-        # Get events from cache
-        events = state.data_hub.get_recent_events(
-            event_types=filter_types,
-            limit=limit,
-        )
-
-        # Build response with envelopes, filtering by since
-        envelopes = []
-        for i, e in enumerate(events):
-            # Events are newest-first, so sequence decreases with index
-            event_sequence = current_sequence - i
-            if since is not None and event_sequence <= since:
-                # Skip events at or before the since sequence
-                continue
-            envelopes.append(
-                EventEnvelope(
-                    trial_id=state.trial_id,
-                    sequence=event_sequence,
-                    timestamp=e.timestamp,
-                    payload=e.to_dict(),
-                )
+        # Build response with real sequences
+        envelopes = [
+            EventEnvelope(
+                trial_id=state.trial_id,
+                sequence=seq,
+                timestamp=event.timestamp,
+                payload=event.to_dict(),
             )
+            for seq, event in sequenced_events
+        ]
 
         # Check if trial has ended
         trial_ended_info = None

--- a/packages/dojozero/src/dojozero/gateway/_server.py
+++ b/packages/dojozero/src/dojozero/gateway/_server.py
@@ -31,6 +31,7 @@ from dojozero.gateway._models import (
     ErrorResponse,
     EventEnvelope,
     RecentEventsResponse,
+    TrialEndedInfo,
     TrialMetadataResponse,
     TrialResultsResponse,
 )
@@ -480,9 +481,19 @@ def create_gateway_app(
                 )
             )
 
+        # Check if trial has ended
+        trial_ended_info = None
+        ended_msg = state.adapter.get_trial_ended_message()
+        if ended_msg is not None:
+            trial_ended_info = TrialEndedInfo(
+                reason=ended_msg.reason,
+                message=ended_msg.message,
+            )
+
         return RecentEventsResponse(
             events=envelopes,
             current_sequence=current_sequence,
+            trial_ended=trial_ended_info,
         )
 
     # =========================================================================

--- a/packages/dojozero/tests/test_oss.py
+++ b/packages/dojozero/tests/test_oss.py
@@ -659,3 +659,148 @@ class TestUploadTrialToOss:
             from dojozero.dashboard_server._trial_manager import upload_trial_to_oss
 
             assert upload_trial_to_oss("trial-123", local_file) is False
+
+
+class TestUploadFileToOss:
+    """Tests for _upload_file_to_oss helper."""
+
+    def test_uploads_file_with_custom_filename(
+        self, tmp_path: Path, _reset_oss_singleton
+    ):
+        local_file = tmp_path / "results.json"
+        local_file.write_text('{"agents": []}')
+
+        mock_client = MagicMock()
+
+        with patch(
+            "dojozero.utils.oss.OSSClient.from_env",
+            return_value=mock_client,
+        ):
+            from dojozero.dashboard_server._trial_manager import _upload_file_to_oss
+
+            result = _upload_file_to_oss("trial-abc", local_file, "results.json")
+
+        assert result is True
+        mock_client.upload_file.assert_called_once_with(
+            local_file, "trials/trial-abc/results.json"
+        )
+
+    def test_returns_false_for_missing_file(self, tmp_path: Path):
+        from dojozero.dashboard_server._trial_manager import _upload_file_to_oss
+
+        result = _upload_file_to_oss(
+            "trial-abc", tmp_path / "nonexistent.json", "results.json"
+        )
+        assert result is False
+
+    def test_returns_false_on_import_error(self, tmp_path: Path, _reset_oss_singleton):
+        local_file = tmp_path / "results.json"
+        local_file.write_text("{}")
+
+        with patch(
+            "dojozero.utils.oss.OSSClient.from_env",
+            side_effect=ImportError("no oss2"),
+        ):
+            from dojozero.dashboard_server._trial_manager import _upload_file_to_oss
+
+            assert _upload_file_to_oss("trial-abc", local_file, "results.json") is False
+
+    def test_returns_false_on_exception(self, tmp_path: Path, _reset_oss_singleton):
+        local_file = tmp_path / "results.json"
+        local_file.write_text("{}")
+
+        mock_client = MagicMock()
+        mock_client.upload_file.side_effect = RuntimeError("network error")
+
+        with patch(
+            "dojozero.utils.oss.OSSClient.from_env",
+            return_value=mock_client,
+        ):
+            from dojozero.dashboard_server._trial_manager import _upload_file_to_oss
+
+            assert _upload_file_to_oss("trial-abc", local_file, "results.json") is False
+
+
+class TestDownloadTrialFileFromOss:
+    """Tests for download_trial_file_from_oss helper."""
+
+    def test_returns_parsed_json(self, tmp_path: Path, _reset_oss_singleton):
+        import json
+
+        expected = {"trial_id": "t1", "agents": [{"name": "a1", "balance": 100}]}
+        mock_client = MagicMock()
+        mock_client.file_exists.return_value = True
+
+        def fake_download(oss_key, local_path):
+            local_path.write_text(json.dumps(expected))
+
+        mock_client.download_file.side_effect = fake_download
+
+        with patch(
+            "dojozero.utils.oss.OSSClient.from_env",
+            return_value=mock_client,
+        ):
+            from dojozero.dashboard_server._trial_manager import (
+                download_trial_file_from_oss,
+            )
+
+            result = download_trial_file_from_oss("trial-abc", "results.json")
+
+        assert result == expected
+        mock_client.file_exists.assert_called_once_with("trials/trial-abc/results.json")
+
+    def test_returns_none_when_not_found(self, _reset_oss_singleton):
+        mock_client = MagicMock()
+        mock_client.file_exists.return_value = False
+
+        with patch(
+            "dojozero.utils.oss.OSSClient.from_env",
+            return_value=mock_client,
+        ):
+            from dojozero.dashboard_server._trial_manager import (
+                download_trial_file_from_oss,
+            )
+
+            result = download_trial_file_from_oss("trial-abc", "results.json")
+
+        assert result is None
+
+    def test_returns_none_on_import_error(self, _reset_oss_singleton):
+        with patch(
+            "dojozero.utils.oss.OSSClient.from_env",
+            side_effect=ImportError("no oss2"),
+        ):
+            from dojozero.dashboard_server._trial_manager import (
+                download_trial_file_from_oss,
+            )
+
+            assert download_trial_file_from_oss("trial-abc") is None
+
+    def test_returns_none_on_exception(self, _reset_oss_singleton):
+        mock_client = MagicMock()
+        mock_client.file_exists.side_effect = RuntimeError("boom")
+
+        with patch(
+            "dojozero.utils.oss.OSSClient.from_env",
+            return_value=mock_client,
+        ):
+            from dojozero.dashboard_server._trial_manager import (
+                download_trial_file_from_oss,
+            )
+
+            assert download_trial_file_from_oss("trial-abc") is None
+
+
+class TestOssTrialKey:
+    """Tests for _oss_trial_key helper."""
+
+    def test_default_filename(self):
+        from dojozero.dashboard_server._trial_manager import _oss_trial_key
+
+        assert _oss_trial_key("t1") == "trials/t1/events.jsonl"
+
+    def test_custom_filename(self):
+        from dojozero.dashboard_server._trial_manager import _oss_trial_key
+
+        assert _oss_trial_key("t1", "results.json") == "trials/t1/results.json"
+        assert _oss_trial_key("t1", "spec.json") == "trials/t1/spec.json"


### PR DESCRIPTION
- Switch client daemon from SSE to polling — external agents now use GET /events/recent?since=N&limit=100 instead of SSE streams. Polling scales better (200 req/s for 1000 agents at 5s interval vs 1000 persistent connections with fan-out).                                                                         
- Fix sequence tracking — the /events/recent endpoint was fabricating sequence numbers as currentSequence - i, causing late-joining clients to miss event types. Now stores real sequence numbers in a sequential cache with binary-search pagination.                                                                 
- Add pagination catch-up — client polls immediately when a full page (100 events) is returned, ensuring late joiners receive all cached events. Verified 404/404 event parity between server and client.                                                                                                              
- Bump event cache to 10,000 per type — up from 100, so late-joining agents get full game history.                                                         
- Fix OSS upload ordering — moved OSS upload into finally blocks after _save_trial_results() to prevent uploading before results.json exists.                
- Fix polymarket poll interval race — pre-game 300s sleep blocked the entire interval even after game_start fired. Now sleeps in 1s ticks so interval changes take effect within 1 second.                                                                                                                                
- Suppress polling noise — filter /events/recent from uvicorn access logs. Default poll interval raised from 2s to 5s.