### PR TITLE
bump version; unify outputs file structure and fix SLS materialization for old trials

### DIFF
--- a/packages/dojozero/pyproject.toml
+++ b/packages/dojozero/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dojozero"
-version = "0.2.2"
+version = "0.3.0"
 description = "A platform for running AI agents on realtime sport data and make predictions about game outcomes."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/dojozero/src/dojozero/cli.py
+++ b/packages/dojozero/src/dojozero/cli.py
@@ -1445,12 +1445,14 @@ async def _resolve_event_files(
     """Resolve event file patterns to actual file paths.
 
     Supports:
-    - Local file paths: outputs/game.jsonl
-    - Local glob patterns: outputs/*/*.jsonl, outputs/2025-01-*/*.jsonl
+    - Local file paths: outputs/{trial_id}.jsonl
+    - Local glob patterns: outputs/*.jsonl
     - HTTP(S) URLs: http://server/api/trials/{id}/events.jsonl
     - OSS URLs: oss://bucket/prefix/file.jsonl
     - OSS glob patterns: oss://bucket/prefix/*.jsonl
     - SLS trace ids: sls://<trial_id>[@<run_id>]
+
+    Downloaded/materialized files are cached under outputs/{trial_id}.jsonl.
 
     Args:
         patterns: List of file patterns, OSS URLs, or sls:// trace ids
@@ -1529,19 +1531,19 @@ async def _resolve_event_files(
             import httpx
 
             url = pattern
-            # Derive a cache filename from the URL path.
-            # For /api/trials/{trial_id}/events.jsonl, use trial_id as the name.
+            # Derive cache path from URL.
+            # For /api/trials/{trial_id}/events.jsonl → outputs/{trial_id}/events.jsonl
             import re as _re
 
             url_path = url.split("?")[0].rstrip("/")
             trial_match = _re.search(r"/api/trials/([^/]+)/events", url_path)
             if trial_match:
-                url_filename = f"{trial_match.group(1)}.jsonl"
+                cache_path = sls_cache / f"{trial_match.group(1)}.jsonl"
             else:
                 url_filename = Path(url_path).name
                 if not url_filename.endswith(".jsonl"):
                     url_filename += ".jsonl"
-            cache_path = sls_cache / url_filename
+                cache_path = sls_cache / url_filename
             if not cache_path.exists():
                 LOGGER.info("Downloading events from %s", url)
                 try:
@@ -1983,9 +1985,10 @@ async def _backtest_command(args: argparse.Namespace) -> int:
             if args.trial_id and total_files == 1:
                 trial_id = args.trial_id
             else:
-                # Use file stem as part of trial_id for traceability
-                file_stem = event_file.stem
-                trial_id = f"{file_stem}-{uuid4().hex[:8]}"
+                # Derive source trial ID from file name:
+                #   outputs/{source_trial_id}.jsonl → use file stem
+                source_id = event_file.stem
+                trial_id = f"{source_id}-bt-{uuid4().hex[:8]}"
 
             LOGGER.info(
                 "=" * 60 + "\nProcessing file %d/%d: %s (trial_id: %s)\n" + "=" * 60,

--- a/packages/dojozero/src/dojozero/core/_tracing.py
+++ b/packages/dojozero/src/dojozero/core/_tracing.py
@@ -550,6 +550,10 @@ class SLSTraceReader:
     SLS provides OpenTelemetry trace storage with a REST API for querying.
     Authentication is handled by alibabacloud-credentials SDK.
 
+    DEFAULT_LOOKBACK_DAYS (7) is used for broad queries (list_trials,
+    get_all_spans).  TRIAL_LOOKBACK_DAYS (365) is used for get_spans
+    which filters by an exact trace_id — wider window, minimal cost.
+
     Credentials (automatic via SDK):
         - Environment variables (ALIBABA_CLOUD_ACCESS_KEY_ID, etc.)
         - Credentials file (~/.alibabacloud/credentials)
@@ -563,6 +567,7 @@ class SLSTraceReader:
     """
 
     DEFAULT_LOOKBACK_DAYS = 7
+    TRIAL_LOOKBACK_DAYS = 365
 
     def __init__(
         self,
@@ -778,9 +783,10 @@ class SLSTraceReader:
         """
         now = datetime.now(timezone.utc)
 
-        # Default time range: 7 days ago to now
+        # Default time range: use TRIAL_LOOKBACK_DAYS (365) for by-trial-id
+        # queries — exact _trace_id match keeps the query efficient.
         if start_time is None:
-            from_time = now - timedelta(days=self.DEFAULT_LOOKBACK_DAYS)
+            from_time = now - timedelta(days=self.TRIAL_LOOKBACK_DAYS)
         else:
             from_time = start_time
 

--- a/packages/dojozero/src/dojozero/dashboard_server/_scheduler.py
+++ b/packages/dojozero/src/dojozero/dashboard_server/_scheduler.py
@@ -715,19 +715,12 @@ class ScheduleManager:
             if "hub" not in config:
                 config["hub"] = {}
 
-            # Generate schedule_id early so we can use it in persistence_file
+            # Generate schedule_id early for dedup
             schedule_id = self._generate_schedule_id(sport_type, game.game_id)
 
-            # Set persistence_file with unique schedule_id to avoid conflicts
-            # Explicit output_dir param overrides server-level output_dir
-            effective_output_dir = output_dir or (
-                str(self._output_dir) if self._output_dir else None
-            )
-            if effective_output_dir:
-                persistence_file = (
-                    f"{effective_output_dir}/{game_date}/{schedule_id}.jsonl"
-                )
-                config["hub"]["persistence_file"] = persistence_file
+            # NOTE: persistence_file is set at launch time (in _launch_trial)
+            # when the trial_id is known, using the canonical path:
+            #   outputs/{trial_id}/events.jsonl
 
             # Add game info to metadata using typed structure
             game_metadata: dict[str, Any] = dict(metadata) if metadata else {}
@@ -1116,19 +1109,12 @@ class ScheduleManager:
             if "hub" not in game_config:
                 game_config["hub"] = {}
 
-            # Generate schedule_id early so we can use it in persistence_file
+            # Generate schedule_id early for dedup
             schedule_id = self._generate_schedule_id(source.sport_type, game.game_id)
 
-            # Set persistence_file with unique schedule_id to avoid conflicts
-            # Per-source output_dir overrides server-level output_dir
-            effective_output_dir = config.output_dir or (
-                str(self._output_dir) if self._output_dir else None
-            )
-            if effective_output_dir:
-                persistence_file = (
-                    f"{effective_output_dir}/{game_date}/{schedule_id}.jsonl"
-                )
-                game_config["hub"]["persistence_file"] = persistence_file
+            # NOTE: persistence_file is set at launch time (in _launch_trial)
+            # when the trial_id is known, using the canonical path:
+            #   outputs/{trial_id}/events.jsonl
 
             # Metadata for the trial using typed structure
             trial_metadata: ScheduledGameMetadata = {
@@ -1600,6 +1586,14 @@ class ScheduleManager:
             hash_suffix = hashlib.sha256(hash_input.encode()).hexdigest()[:8]
             trial_id = f"{scheduled.sport_type}-game-{scheduled.game_id}-{hash_suffix}"
 
+            # Set persistence_file now that trial_id is known:
+            #   outputs/{trial_id}.jsonl
+            if self._output_dir:
+                pf = str(self._output_dir / f"{trial_id}.jsonl")
+                if "hub" not in scheduled.scenario_config:
+                    scheduled.scenario_config["hub"] = {}
+                scheduled.scenario_config["hub"]["persistence_file"] = pf
+
             # Pick target server if peer registry available
             target_peer = None
             if self._peer_registry is not None:
@@ -1810,15 +1804,6 @@ class ScheduleManager:
                 or target_peer.server_id == self._server_id
             ):
                 self._register_game_result_callback(scheduled)
-
-                # Create symlink in outputs/trials/ for trial-id-indexed lookup
-                pf = scheduled.scenario_config.get("hub", {}).get("persistence_file")
-                if pf and self._output_dir:
-                    from dojozero.dashboard_server._trial_manager import (
-                        ensure_trial_symlink,
-                    )
-
-                    ensure_trial_symlink(self._output_dir, trial_id, Path(pf))
 
             LOGGER.info(
                 "Launched trial '%s' for schedule '%s'",

--- a/packages/dojozero/src/dojozero/dashboard_server/_server.py
+++ b/packages/dojozero/src/dojozero/dashboard_server/_server.py
@@ -49,8 +49,8 @@ from dojozero.core._tracing import (
 )
 from dojozero.core._types import RuntimeContext
 from dojozero.dashboard_server._trial_manager import (
+    _legacy_trials_cache_path,
     download_trial_from_oss,
-    ensure_trial_symlink,
     trials_cache_path,
     upload_trial_to_oss,
 )
@@ -876,20 +876,14 @@ def create_dashboard_app(
         builder_config = dict(scenario.config or scenario_config)
         output_base = state.output_dir
 
-        # Generate safe persistence_file path based on trial_id
-        from datetime import date
-
-        date_str = date.today().isoformat()
-        safe_persistence_file = (
-            output_base / scenario.name / date_str / f"{trial_id}.jsonl"
-        )
+        # Generate safe persistence_file: outputs/{trial_id}.jsonl
+        safe_persistence_file = output_base / f"{trial_id}.jsonl"
         safe_persistence_file.parent.mkdir(parents=True, exist_ok=True)
 
         # Inject into hub config (override any user-provided value)
         if "hub" not in builder_config:
             builder_config["hub"] = {}
         builder_config["hub"]["persistence_file"] = str(safe_persistence_file)
-        ensure_trial_symlink(state.output_dir, trial_id, safe_persistence_file)
         LOGGER.debug(
             "Generated persistence_file for trial %s: %s",
             trial_id,
@@ -1293,8 +1287,7 @@ def create_dashboard_app(
         """
         from fastapi.responses import FileResponse
 
-        # 1. Try canonical trials cache (symlinks for live, real files for
-        #    OSS/SLS cached).  Path.exists() follows symlinks transparently.
+        # 1. Try canonical path: outputs/{trial_id}/events.jsonl
         cached_path = trials_cache_path(state.output_dir, trial_id, run_id)
         event_file: Path | None = None
         if cached_path.exists():
@@ -1304,7 +1297,15 @@ def create_dashboard_app(
             # can write a real file at this path.
             cached_path.unlink()
 
-        # 2. Try OSS
+        # 1b. Legacy fallback: outputs/trials/{trial_id}.jsonl
+        if event_file is None:
+            legacy = _legacy_trials_cache_path(state.output_dir, trial_id, run_id)
+            if legacy.exists():
+                event_file = legacy
+            elif legacy.is_symlink():
+                legacy.unlink()
+
+        # 2. Try OSS (downloads to the new canonical path)
         if event_file is None and download_trial_from_oss(trial_id, cached_path):
             event_file = cached_path
 
@@ -1371,6 +1372,20 @@ def create_dashboard_app(
                     },
                     status_code=424,
                 )
+
+        # Guard against serving empty files (e.g. from a previous failed
+        # materialization).  Remove the empty file so future requests retry.
+        if event_file.stat().st_size == 0:
+            event_file.unlink(missing_ok=True)
+            return JSONResponse(
+                content={
+                    "error": (
+                        f"Event file for trial '{trial_id}' is empty (0 events). "
+                        "Deleted cached file — retry to re-fetch from SLS."
+                    )
+                },
+                status_code=404,
+            )
 
         return FileResponse(
             path=event_file,

--- a/packages/dojozero/src/dojozero/dashboard_server/_trial_manager.py
+++ b/packages/dojozero/src/dojozero/dashboard_server/_trial_manager.py
@@ -1476,6 +1476,17 @@ def trials_cache_path(
 ) -> Path:
     """Canonical local cache path for a trial's event file.
 
+    Returns ``output_dir / "{trial_id}[-{run_id[:8]}].jsonl"``.
+    """
+    suffix = f"-{run_id[:8]}" if run_id else ""
+    return output_dir / f"{trial_id}{suffix}.jsonl"
+
+
+def _legacy_trials_cache_path(
+    output_dir: Path, trial_id: str, run_id: str | None = None
+) -> Path:
+    """Legacy path for backwards compatibility.
+
     Returns ``output_dir / "trials" / "{trial_id}[-{run_id[:8]}].jsonl"``.
     """
     suffix = f"-{run_id[:8]}" if run_id else ""
@@ -1494,7 +1505,7 @@ def ensure_trial_symlink(
     """
     import os
 
-    link_path = trials_cache_path(output_dir, trial_id)
+    link_path = _legacy_trials_cache_path(output_dir, trial_id)
     link_path.parent.mkdir(parents=True, exist_ok=True)
     try:
         target = os.path.relpath(persistence_file, link_path.parent)
@@ -1670,6 +1681,7 @@ __all__ = [
     "QueuedTrialPhase",
     "TrialManager",
     "download_trial_file_from_oss",
+    "_legacy_trials_cache_path",
     "download_trial_from_oss",
     "ensure_trial_symlink",
     "trials_cache_path",

--- a/packages/dojozero/src/dojozero/data/_sls_source.py
+++ b/packages/dojozero/src/dojozero/data/_sls_source.py
@@ -146,6 +146,13 @@ class SLSEventSource:
             spans, trial_id=trial_id, run_id=run_id
         )
 
+        if not events:
+            raise RuntimeError(
+                f"SLS materialization produced 0 events for trial '{trial_id}'. "
+                "The trial may not exist in SLS, may still be running, "
+                "or spans may have expired."
+            )
+
         dest.parent.mkdir(parents=True, exist_ok=True)
         tmp = dest.with_suffix(f"{dest.suffix}.{uuid.uuid4().hex}.tmp")
         try:

--- a/packages/dojozero/tests/test_backtest_cache_naming.py
+++ b/packages/dojozero/tests/test_backtest_cache_naming.py
@@ -1,6 +1,6 @@
 """Tests for trial cache filename scheme and symlink helpers.
 
-The server and CLI use a canonical ``outputs/trials/`` directory:
+The server and CLI use a canonical ``outputs/`` directory:
   {trial_id}.jsonl              (no run_id)
   {trial_id}-{run_id[:8]}.jsonl (with run_id)
 
@@ -12,6 +12,7 @@ import os
 from pathlib import Path
 
 from dojozero.dashboard_server._trial_manager import (
+    _legacy_trials_cache_path,
     ensure_trial_symlink,
     trials_cache_path,
 )
@@ -22,24 +23,36 @@ class TestTrialsCachePath:
 
     def test_no_run_id(self, tmp_path: Path) -> None:
         result = trials_cache_path(tmp_path, "abc123")
-        assert result == tmp_path / "trials" / "abc123.jsonl"
+        assert result == tmp_path / "abc123.jsonl"
 
     def test_empty_run_id(self, tmp_path: Path) -> None:
         result = trials_cache_path(tmp_path, "abc123", "")
-        assert result == tmp_path / "trials" / "abc123.jsonl"
+        assert result == tmp_path / "abc123.jsonl"
 
     def test_with_run_id(self, tmp_path: Path) -> None:
         result = trials_cache_path(tmp_path, "trial-1", "abcdef1234567890")
-        assert result == tmp_path / "trials" / "trial-1-abcdef12.jsonl"
+        assert result == tmp_path / "trial-1-abcdef12.jsonl"
 
     def test_short_run_id(self, tmp_path: Path) -> None:
         result = trials_cache_path(tmp_path, "trial-1", "abc")
-        assert result == tmp_path / "trials" / "trial-1-abc.jsonl"
+        assert result == tmp_path / "trial-1-abc.jsonl"
 
     def test_different_run_ids(self, tmp_path: Path) -> None:
         p1 = trials_cache_path(tmp_path, "trial-1", "run_aaa_1234")
         p2 = trials_cache_path(tmp_path, "trial-1", "run_bbb_5678")
         assert p1 != p2
+
+
+class TestLegacyTrialsCachePath:
+    """Verify _legacy_trials_cache_path still produces old-style paths."""
+
+    def test_no_run_id(self, tmp_path: Path) -> None:
+        result = _legacy_trials_cache_path(tmp_path, "abc123")
+        assert result == tmp_path / "trials" / "abc123.jsonl"
+
+    def test_with_run_id(self, tmp_path: Path) -> None:
+        result = _legacy_trials_cache_path(tmp_path, "trial-1", "abcdef1234567890")
+        assert result == tmp_path / "trials" / "trial-1-abcdef12.jsonl"
 
 
 class TestCacheHitMiss:
@@ -48,14 +61,14 @@ class TestCacheHitMiss:
     def test_cache_hit_skips_materialization(self, tmp_path: Path) -> None:
         """When cache file exists, no SLS fetch should be needed."""
         p = trials_cache_path(tmp_path, "trial-xyz", "run12345678abcdef")
-        p.parent.mkdir(parents=True)
+        p.parent.mkdir(parents=True, exist_ok=True)
         p.write_text('{"event": "test"}\n')
         assert p.exists()
 
     def test_cache_miss_for_different_run_id(self, tmp_path: Path) -> None:
         """A cached file for run_A should NOT satisfy a request for run_B."""
         p_a = trials_cache_path(tmp_path, "trial-xyz", "run_aaaa_xxx")
-        p_a.parent.mkdir(parents=True)
+        p_a.parent.mkdir(parents=True, exist_ok=True)
         p_a.write_text('{"event": "test"}\n')
 
         p_b = trials_cache_path(tmp_path, "trial-xyz", "run_bbbb_xxx")
@@ -64,7 +77,7 @@ class TestCacheHitMiss:
     def test_no_run_id_does_not_match_run_id_file(self, tmp_path: Path) -> None:
         """A request with no run_id should not reuse a run_id-specific cache."""
         specific = trials_cache_path(tmp_path, "trial-xyz", "run_aaaa_xxx")
-        specific.parent.mkdir(parents=True)
+        specific.parent.mkdir(parents=True, exist_ok=True)
         specific.write_text('{"event": "test"}\n')
 
         plain = trials_cache_path(tmp_path, "trial-xyz")
@@ -72,7 +85,7 @@ class TestCacheHitMiss:
 
 
 class TestEnsureTrialSymlink:
-    """Tests for ensure_trial_symlink helper."""
+    """Tests for ensure_trial_symlink helper (legacy, kept for compatibility)."""
 
     def test_creates_symlink(self, tmp_path: Path) -> None:
         persistence = tmp_path / "2026-04-21" / "sched-nba-123.jsonl"

--- a/packages/dojozero/tests/test_sls_source.py
+++ b/packages/dojozero/tests/test_sls_source.py
@@ -660,8 +660,9 @@ def test_materialize_result_returns_chosen_run_id(tmp_path: Path) -> None:
 def test_materialize_result_explicit_run_id(tmp_path: Path) -> None:
     """Explicit run_id is reflected in the result."""
     trace_id = "trial-multi"
-    root_a = _root_span(trace_id, span_id="rootA")
-    root_b = _root_span(trace_id, span_id="rootB")
+    # Give roots different start times so events group correctly by time proximity
+    root_a = _root_span(trace_id, span_id="rootA", start_time_us=1_000_000)
+    root_b = _root_span(trace_id, span_id="rootB", start_time_us=5_000_000)
     spans = [
         root_a,
         root_b,
@@ -669,11 +670,13 @@ def test_materialize_result_explicit_run_id(tmp_path: Path) -> None:
             _make_init(game_id="a1"),
             trace_id=trace_id,
             parent_span_id=root_a.span_id,
+            start_time_us=2_000_000,
         ),
         _event_span(
             _make_init(game_id="b1"),
             trace_id=trace_id,
             parent_span_id=root_b.span_id,
+            start_time_us=6_000_000,
         ),
     ]
     source = SLSEventSource(reader=_FakeReader(spans))

--- a/tools/nba_trial_runner.py
+++ b/tools/nba_trial_runner.py
@@ -14,11 +14,11 @@ When using --server flag, trials are submitted to a Dashboard Server which handl
 
 Usage:
     # Local mode (no trace export to server)
-    python nba_trial_runner.py run --data-dir outputs
+    python nba_trial_runner.py run --output-dir outputs
 
     # Server mode (traces exported via Dashboard Server)
     # First start: dojo0 serve --trace-backend jaeger
-    python nba_trial_runner.py run --data-dir outputs --server http://localhost:8000
+    python nba_trial_runner.py run --output-dir outputs --server http://localhost:8000
 """
 
 # Load .env file before importing other modules
@@ -59,8 +59,7 @@ class GameTrialManager:
         base_config: Path,
         pre_start_hours: float = 0.1,
         check_interval_seconds: float = 60.0,
-        data_dir: Path | None = None,
-        game_date: str | None = None,
+        output_dir: Path = Path("outputs"),
         log_level: str = "INFO",
         server: str | None = None,
     ):
@@ -71,9 +70,8 @@ class GameTrialManager:
             base_config: Path to base config template
             pre_start_hours: Hours before game to start trial (default: 0.1)
             check_interval_seconds: Interval to check game status (default: 60.0)
-            data_dir: If provided, use {data_dir}/{date}/{game_id}.yaml and {data_dir}/{date}/{game_id}.jsonl
-                      If None, use defaults: configs/ and outputs/
-            game_date: Date string (YYYY-MM-DD) for date-organized structure
+            output_dir: Directory for output files (default: outputs/).
+                        Files are written as {output_dir}/{trial_id}.jsonl, .yaml, .log
             log_level: Logging level for subprocess (default: INFO)
             server: Dashboard Server URL (e.g., http://localhost:8000). If provided,
                     trials are submitted to the server which exports traces to Jaeger.
@@ -83,8 +81,7 @@ class GameTrialManager:
         self.base_config = base_config
         self.pre_start_hours = pre_start_hours
         self.check_interval_seconds = check_interval_seconds
-        self.data_dir = data_dir
-        self.game_date = game_date
+        self.output_dir = output_dir
         self.log_level = log_level
         self.server = server
 
@@ -156,34 +153,23 @@ class GameTrialManager:
         # Update espn_game_id
         config["scenario"]["config"]["espn_game_id"] = self.game_id
 
-        # Determine file paths
-        if self.data_dir:
-            # Data dir structure: {data_dir}/{date}/{game_id}.yaml, {game_id}.jsonl, {game_id}.log
-            if not self.game_date:
-                # If data_dir is provided but no game_date, use today's date
-                self.game_date = datetime.now().strftime("%Y-%m-%d")
-            date_dir = self.data_dir / self.game_date
-            config_file = date_dir / f"{self.game_id}.yaml"
-            events_file = date_dir / f"{self.game_id}.jsonl"
-            log_file = date_dir / f"{self.game_id}.log"
-        else:
-            # Flat structure: use default directories
-            project_root = Path(__file__).parent.parent
-            configs_dir = project_root / "configs"
-            outputs_dir = project_root / "outputs"
-            config_file = configs_dir / f"nba-moneyline_{self.game_id}.yaml"
-            events_file = outputs_dir / f"nba_betting_events_{self.game_id}.jsonl"
-            log_file = outputs_dir / f"{self.game_id}.log"
+        # Generate trial_id first — file paths derive from it.
+        import hashlib
+
+        hash_input = f"{self.game_id}-{datetime.now(timezone.utc).isoformat()}"
+        hash_suffix = hashlib.sha256(hash_input.encode()).hexdigest()[:8]
+        self.trial_id = f"nba-game-{self.game_id}-{hash_suffix}"
+
+        # All output files live under output_dir as {trial_id}.*
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+        config_file = self.output_dir / f"{self.trial_id}.yaml"
+        events_file = self.output_dir / f"{self.trial_id}.jsonl"
+        log_file = self.output_dir / f"{self.trial_id}.log"
 
         # Update persistence file in config
         if "hub" not in config["scenario"]["config"]:
             config["scenario"]["config"]["hub"] = {}
         config["scenario"]["config"]["hub"]["persistence_file"] = str(events_file)
-
-        # Create directory structure
-        config_file.parent.mkdir(parents=True, exist_ok=True)
-        events_file.parent.mkdir(parents=True, exist_ok=True)
-        log_file.parent.mkdir(parents=True, exist_ok=True)
 
         # Save config file
         with open(config_file, "w") as f:
@@ -192,14 +178,6 @@ class GameTrialManager:
         self.config_file = config_file
         self.events_file = events_file
         self.log_file = log_file
-
-        # Unique trial ID with hash suffix so each run gets its own SLS traces.
-        # Prefixed with adhoc_ to distinguish from scheduler-launched trials.
-        import hashlib
-
-        hash_input = f"{self.game_id}-{datetime.now(timezone.utc).isoformat()}"
-        hash_suffix = hashlib.sha256(hash_input.encode()).hexdigest()[:8]
-        self.trial_id = f"adhoc_nba_game_{self.game_id}_{hash_suffix}"
 
         # Set up file logger for this game
         self._setup_file_logger()
@@ -402,7 +380,11 @@ class GameTrialManager:
             Game status (1=scheduled, 2=in progress, 3=finished) or None if error
         """
         try:
-            check_date = self.game_date or datetime.now().strftime("%Y-%m-%d")
+            check_date = (
+                self.game_time_utc.strftime("%Y-%m-%d")
+                if self.game_time_utc
+                else datetime.now().strftime("%Y-%m-%d")
+            )
             games = get_games_for_date(check_date, print_games=False)
             current_game = next(
                 (g for g in games if str(g.get("gameId")) == self.game_id), None
@@ -746,7 +728,7 @@ async def run_trial_for_game(
     base_config: Path,
     pre_start_hours: float = 2.0,
     check_interval_seconds: float = 60.0,
-    data_dir: Path | None = None,
+    output_dir: Path = Path("outputs"),
     log_level: str = "INFO",
     server: str | None = None,
 ) -> list[GameTrialManager]:
@@ -760,8 +742,7 @@ async def run_trial_for_game(
         base_config: Path to base config template
         pre_start_hours: Hours before game to start trial
         check_interval_seconds: Interval to check game status
-        data_dir: If provided, use {data_dir}/{date}/{game_id}.yaml and {data_dir}/{date}/{game_id}.jsonl
-                  If None, use defaults: configs/ and outputs/
+        output_dir: Directory for output files (default: outputs/)
         log_level: Logging level for subprocess
         server: Dashboard Server URL for trace export
 
@@ -805,8 +786,7 @@ async def run_trial_for_game(
         base_config=base_config,
         pre_start_hours=pre_start_hours,
         check_interval_seconds=check_interval_seconds,
-        data_dir=data_dir,
-        game_date=game_date_str if data_dir else None,
+        output_dir=output_dir,
         log_level=log_level,
         server=server,
     )
@@ -821,7 +801,7 @@ async def run_trials_for_date(
     base_config: Path,
     pre_start_hours: float = 2.0,
     check_interval_seconds: float = 60.0,
-    data_dir: Path | None = None,
+    output_dir: Path = Path("outputs"),
     log_level: str = "INFO",
     server: str | None = None,
 ) -> list[GameTrialManager]:
@@ -832,20 +812,13 @@ async def run_trials_for_date(
         base_config: Path to base config template
         pre_start_hours: Hours before game to start trial
         check_interval_seconds: Interval to check game status
-        data_dir: If provided, use {data_dir}/{date}/{game_id}.yaml and {data_dir}/{date}/{game_id}.jsonl
-                  If None, use defaults: configs/ and outputs/
+        output_dir: Directory for output files (default: outputs/)
         log_level: Logging level for subprocess
         server: Dashboard Server URL for trace export
 
     Returns:
         List of GameTrialManager instances
     """
-    # Parse date string
-    if isinstance(game_date, datetime):
-        date_str = game_date.strftime("%Y-%m-%d")
-    else:
-        date_str = game_date
-
     # Get games for date
     logger.info("Fetching games for date: %s", game_date)
     games = get_games_for_date(game_date, print_games=True)
@@ -867,10 +840,7 @@ async def run_trials_for_date(
             base_config=base_config,
             pre_start_hours=pre_start_hours,
             check_interval_seconds=check_interval_seconds,
-            data_dir=data_dir,
-            game_date=(
-                date_str if data_dir else None
-            ),  # Pass date_str when data_dir is set
+            output_dir=output_dir,
             log_level=log_level,
             server=server,
         )
@@ -1083,10 +1053,10 @@ def main() -> int:
         help="Path to trial config template (default: trial_params/nba-moneyline.yaml)",
     )
     run_parser.add_argument(
-        "--data-dir",
+        "--output-dir",
         type=Path,
-        default=None,
-        help="Data directory for output: {data-dir}/{date}/{game_id}.yaml and {data-dir}/{date}/{game_id}.jsonl",
+        default=Path("outputs"),
+        help="Output directory for trial files: {output-dir}/{trial_id}.jsonl, .yaml, .log",
     )
     run_parser.add_argument(
         "--pre-start-hours",
@@ -1162,7 +1132,7 @@ def main() -> int:
                         base_config=args.config,
                         pre_start_hours=args.pre_start_hours,
                         check_interval_seconds=args.check_interval,
-                        data_dir=args.data_dir,
+                        output_dir=args.output_dir,
                         log_level=args.log_level,
                         server=args.server,
                     )
@@ -1180,7 +1150,7 @@ def main() -> int:
                         base_config=args.config,
                         pre_start_hours=args.pre_start_hours,
                         check_interval_seconds=args.check_interval,
-                        data_dir=args.data_dir,
+                        output_dir=args.output_dir,
                         log_level=args.log_level,
                         server=args.server,
                     )

--- a/tools/nba_trial_runner.py
+++ b/tools/nba_trial_runner.py
@@ -158,7 +158,7 @@ class GameTrialManager:
 
         hash_input = f"{self.game_id}-{datetime.now(timezone.utc).isoformat()}"
         hash_suffix = hashlib.sha256(hash_input.encode()).hexdigest()[:8]
-        self.trial_id = f"nba-game-{self.game_id}-{hash_suffix}"
+        self.trial_id = f"adhoc_nba_game_{self.game_id}_{hash_suffix}"
 
         # All output files live under output_dir as {trial_id}.*
         self.output_dir.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
- Fix SLS lookback for old trials: SLSTraceReader.get_spans() now uses a 365-day lookback (was 7 days) when fetching by trial ID, so older trials can be materialized from SLS
- Guard against empty materialization: SLS source raises RuntimeError if materialization produces 0 events; server deletes cached empty files and returns a clear 404
- Flatten output file structure: Trial cache files move from outputs/trials/{trial_id}.jsonl to outputs/{trial_id}.jsonl, with legacy fallback for existing files
- Align nba_trial_runner with scheduler: Replace --data-dir/--game-date with --output-dir (default: outputs/), so adhoc trials use the same flat outputs/{trial_id}.* layout
- Scheduler sets persistence_file at launch time (not schedule time), after trial_id is generated, writing directly to outputs/{trial_id}.jsonl
- Backtest trial IDs: Now {source_trial_id}-bt-{hex8} instead of {file_stem}-{hex8}