### PR TITLE
ci: add Claude Code GitHub workflows

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,10 +2,11 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened, synchronize, ready_for_review]
 
 jobs:
   claude-review:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,40 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  claude-review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code Review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            Please review this pull request. Use the `gh` CLI to fetch PR details (title, body, diff, files changed) and post your review as a single comment via `gh pr comment`.
+
+            Focus on:
+            - Code correctness and potential bugs
+            - Adherence to the conventions in CLAUDE.md (actor model, event sourcing, dataclass/Pydantic patterns, async patterns)
+            - Test coverage for new behavior
+            - Type-checking and lint concerns pyright/ruff would flag
+            - Security issues (input validation, secrets, etc.)
+
+            Be concise. Skip nits unless they affect correctness.
+          claude_args: '--allowed-tools "Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh search:*)"'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,36 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ requires-python = ">=3.11"
 
 [tool.uv.workspace]
 members = ["packages/*"]
+exclude = ["packages/dojozero-agent-runner"]
 
 [tool.uv.sources]
 dojozero = { workspace = true }


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/claude.yml` — responds to `@claude` mentions on issues, PR comments, and reviews.
- Adds `.github/workflows/claude-code-review.yml` — auto-reviews every PR open/synchronize, prompt-tuned to CLAUDE.md conventions (actor model, Pydantic/dataclass patterns, async, pyright/ruff).
- Excludes `packages/dojozero-agent-runner` from the uv workspace since it currently lacks a `pyproject.toml`.

## Setup required
- `CLAUDE_CODE_OAUTH_TOKEN` secret must be added at the repo or org level (already done by @cyruszhang).
- Claude GitHub App is installed on the org for this repo.

## Test plan
- [ ] CI checks pass on this PR
- [ ] `claude-code-review` workflow auto-runs on this PR and posts a review comment
- [ ] After merge, comment `@claude ...` on an issue and verify the mention workflow fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)